### PR TITLE
LP-206 Use constant from api-security-java

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipController.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipController.java
@@ -16,7 +16,7 @@ import uk.gov.companieshouse.limitedpartnershipsapi.utils.ApiLogger;
 import java.net.URI;
 import java.util.HashMap;
 
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.ERIC_IDENTITY;
+import static uk.gov.companieshouse.api.util.security.EricConstants.ERIC_IDENTITY;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_PARAM_TRANSACTION_ID;
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
@@ -6,7 +6,6 @@ public class Constants {
 
     // Request header names
     public static final String ERIC_REQUEST_ID_KEY = "X-Request-Id";
-    public static final String ERIC_IDENTITY = "ERIC-identity";
 
     // URL path parameters
     public static final String URL_PARAM_TRANSACTION_ID = "transaction_id";


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-206


### Change description
Removing our own constant for ERIC Identity, and using the one defined in api-security-java instead.
The 'X-Request-Id' constant doesn't appear to be in that library so will keep using our own constant for that.


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.