### PR TITLE
Make transactionInterceptor run after authentication

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfig.java
@@ -37,12 +37,12 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(@NonNull InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor);
-        registry.addInterceptor(transactionInterceptor())
-                .addPathPatterns(FILINGS, TRANSACTIONS);
         registry.addInterceptor(new TokenPermissionsInterceptor())
                 .addPathPatterns(PARTNERSHIP);
         registry.addInterceptor(customUserAuthenticationInterceptor)
                 .addPathPatterns(PARTNERSHIP);
+        registry.addInterceptor(transactionInterceptor())
+                .addPathPatterns(FILINGS, TRANSACTIONS);
     }
 
     @Bean

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfigTest.java
@@ -45,9 +45,9 @@ class InterceptorConfigTest {
 
         InOrder inOrder = inOrder(interceptorRegistry, interceptorRegistration);
         inOrder.verify(interceptorRegistry).addInterceptor(loggingInterceptor);
-        inOrder.verify(interceptorRegistry).addInterceptor(any(TransactionInterceptor.class));
         inOrder.verify(interceptorRegistry).addInterceptor(any(TokenPermissionsInterceptor.class));
         inOrder.verify(interceptorRegistry).addInterceptor(customUserAuthenticationInterceptor);
+        inOrder.verify(interceptorRegistry).addInterceptor(any(TransactionInterceptor.class));
 
         verify(interceptorRegistry, times(4)).addInterceptor(any());
     }


### PR DESCRIPTION
### JIRA link
NA


### Change description
Changing the order of the interceptors as I noticed the transactionInterceptor was running before the user was authenticated


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.