### PR TITLE
LP-416 New end-point to get LP Incorporation resources

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationController.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationController.java
@@ -1,24 +1,31 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.controller;
 
-import static uk.gov.companieshouse.api.util.security.EricConstants.ERIC_IDENTITY;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.ERIC_REQUEST_ID_KEY;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.TRANSACTION_KEY;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_PARAM_TRANSACTION_ID;
-
-import java.net.URI;
-import java.util.HashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.limitedpartnershipsapi.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipIncorporationDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipSubmissionCreatedResponseDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.LimitedPartnershipIncorporationService;
 import uk.gov.companieshouse.limitedpartnershipsapi.utils.ApiLogger;
+
+import java.net.URI;
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.api.util.security.EricConstants.ERIC_IDENTITY;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.TRANSACTION_KEY;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_PARAM_FILING_RESOURCE_ID;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_PARAM_TRANSACTION_ID;
 
 @RestController
 @RequestMapping("/transactions/{" + URL_PARAM_TRANSACTION_ID + "}/incorporation/limited-partnership")
@@ -48,4 +55,24 @@ public class IncorporationController {
         return ResponseEntity.created(location).body(response);
     }
 
+    @GetMapping("/{" + URL_PARAM_FILING_RESOURCE_ID + "}")
+    public ResponseEntity<Object> getIncorporation(
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
+            @PathVariable(URL_PARAM_FILING_RESOURCE_ID) String filingResourceId,
+            @RequestParam(value = "include_sub_resources", required = true) boolean includeSubResources,
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId
+    ) {
+        var transactionId = transaction.getId();
+        var logMap = new HashMap<String, Object>();
+        logMap.put(URL_PARAM_TRANSACTION_ID, transactionId);
+        ApiLogger.infoContext(requestId, "Calling service to get a Limited Partnership Incorporation, include_sub_resources = " + includeSubResources, logMap);
+
+        try {
+            LimitedPartnershipIncorporationDto dto = incorporationService.getIncorporation(transaction, filingResourceId, includeSubResources);
+            return ResponseEntity.ok().body(dto);
+        } catch (ResourceNotFoundException e) {
+            ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);
+            return ResponseEntity.notFound().build();
+        }
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipIncorporationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipIncorporationMapper.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.limitedpartnershipsapi.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dao.LimitedPartnershipIncorporationDao;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipIncorporationDto;
+
+@Component
+@Mapper(componentModel = "spring")
+public interface LimitedPartnershipIncorporationMapper {
+
+    LimitedPartnershipIncorporationMapper INSTANCE = Mappers.getMapper(LimitedPartnershipIncorporationMapper.class);
+
+    // TODO Map etag
+    @Mapping(target = "kind", source = "dao.data.kind")
+    LimitedPartnershipIncorporationDto daoToDto(LimitedPartnershipIncorporationDao dao);
+}

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/dto/LimitedPartnershipIncorporationDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/dto/LimitedPartnershipIncorporationDto.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.limitedpartnershipsapi.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LimitedPartnershipIncorporationDto {
+
+    @JsonProperty("kind")
+    private String kind;
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipIncorporationService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipIncorporationService.java
@@ -1,23 +1,38 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.service;
 
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.LINK_SELF;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.limitedpartnershipsapi.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.limitedpartnershipsapi.mapper.LimitedPartnershipIncorporationMapper;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dao.LimitedPartnershipIncorporationDao;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipIncorporationDto;
+import uk.gov.companieshouse.limitedpartnershipsapi.repository.LimitedPartnershipIncorporationRepository;
+import uk.gov.companieshouse.limitedpartnershipsapi.utils.TransactionUtils;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.limitedpartnershipsapi.model.dao.LimitedPartnershipIncorporationDao;
-import uk.gov.companieshouse.limitedpartnershipsapi.repository.LimitedPartnershipIncorporationRepository;
+
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.LINK_SELF;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
 
 @Service
 public class LimitedPartnershipIncorporationService {
 
     public static final String LIMITED_PARTNERSHIP_REGISTRATION_KIND = "limited-partnership-registration";
+
     private final LimitedPartnershipIncorporationRepository repository;
 
+    private final LimitedPartnershipIncorporationMapper mapper;
+
+    private final TransactionUtils transactionUtils;
+
     public LimitedPartnershipIncorporationService(
-            LimitedPartnershipIncorporationRepository repository) {
+            LimitedPartnershipIncorporationRepository repository,
+            LimitedPartnershipIncorporationMapper mapper,
+            TransactionUtils transactionUtils) {
         this.repository = repository;
+        this.mapper = mapper;
+        this.transactionUtils = transactionUtils;
     }
 
     public String createIncorporation(String userId, String transaction) {
@@ -35,8 +50,27 @@ public class LimitedPartnershipIncorporationService {
         return insertedIncorporation.getId();
     }
 
+
+    public LimitedPartnershipIncorporationDto getIncorporation(Transaction transaction,
+                                                               String filingResourceId,
+                                                               boolean includeSubResources) throws ResourceNotFoundException {
+        String submissionUri = getSubmissionUri(transaction.getId(), filingResourceId);
+        if (!transactionUtils.isTransactionLinkedToLimitedPartnershipIncorporation(transaction, submissionUri)) {
+            throw new ResourceNotFoundException(String.format(
+                    "Transaction id: %s does not have a resource that matches incorporation id: %s", transaction.getId(), filingResourceId));
+        }
+
+        var submission = repository.findById(filingResourceId);
+        LimitedPartnershipIncorporationDao incorporationDao = submission.orElseThrow(() -> new ResourceNotFoundException(String.format("Incorporation with id %s not found", filingResourceId)));
+
+        // TODO Use value of 'includeSubResources' to retrieve further LP data, if set to 'true'
+
+        return mapper.daoToDto(incorporationDao);
+    }
+
+
     private void updateIncorporationTypeWithSelfLink(LimitedPartnershipIncorporationDao incorporationDao,
-            String submissionUri) {
+                                                     String submissionUri) {
         incorporationDao.setLinks(Collections.singletonMap(LINK_SELF, submissionUri));
         repository.save(incorporationDao);
     }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
@@ -11,6 +11,7 @@ public class Constants {
     // URL path parameters
     public static final String URL_PARAM_TRANSACTION_ID = "transactionId";
     public static final String URL_PARAM_SUBMISSION_ID = "submissionId";
+    public static final String URL_PARAM_FILING_RESOURCE_ID = "filingResourceId";
 
     public static final String TRANSACTION_KEY = "transaction";
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/TransactionUtils.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/TransactionUtils.java
@@ -6,6 +6,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 import java.util.Objects;
 
+import static uk.gov.companieshouse.limitedpartnershipsapi.service.LimitedPartnershipIncorporationService.LIMITED_PARTNERSHIP_REGISTRATION_KIND;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_LIMITED_PARTNERSHIP;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.LINK_RESOURCE;
 
@@ -13,7 +14,15 @@ import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.LINK_
 public class TransactionUtils {
 
     public boolean isTransactionLinkedToLimitedPartnershipSubmission(Transaction transaction, String limitedPartnershipSubmissionSelfLink) {
-        if (StringUtils.isBlank(limitedPartnershipSubmissionSelfLink)) {
+        return doChecks(transaction, limitedPartnershipSubmissionSelfLink, FILING_KIND_LIMITED_PARTNERSHIP);
+    }
+
+    public boolean isTransactionLinkedToLimitedPartnershipIncorporation(Transaction transaction, String limitedPartnershipIncorporationSelfLink) {
+        return doChecks(transaction, limitedPartnershipIncorporationSelfLink, LIMITED_PARTNERSHIP_REGISTRATION_KIND);
+    }
+
+    private boolean doChecks(Transaction transaction, String selfLink, String kind) {
+        if (StringUtils.isBlank(selfLink)) {
             return false;
         }
 
@@ -22,7 +31,7 @@ public class TransactionUtils {
         }
 
         return transaction.getResources().entrySet().stream()
-                .filter(resource -> FILING_KIND_LIMITED_PARTNERSHIP.equals(resource.getValue().getKind()))
-                .anyMatch(resource -> limitedPartnershipSubmissionSelfLink.equals(resource.getValue().getLinks().get(LINK_RESOURCE)));
+                .filter(resource -> kind.equals(resource.getValue().getKind()))
+                .anyMatch(resource -> selfLink.equals(resource.getValue().getLinks().get(LINK_RESOURCE)));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerTest.java
@@ -1,12 +1,5 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
-
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,9 +8,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.limitedpartnershipsapi.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.ServiceException;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipIncorporationDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipSubmissionCreatedResponseDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.LimitedPartnershipIncorporationService;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.limitedpartnershipsapi.service.LimitedPartnershipIncorporationService.LIMITED_PARTNERSHIP_REGISTRATION_KIND;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
 
 @ExtendWith(MockitoExtension.class)
 class IncorporationControllerTest {
@@ -61,5 +64,46 @@ class IncorporationControllerTest {
         LimitedPartnershipSubmissionCreatedResponseDto responseBody = (LimitedPartnershipSubmissionCreatedResponseDto) response.getBody();
         assert responseBody != null;
         assertEquals(SUBMISSION_ID, responseBody.id());
+    }
+
+    @Test
+    void testGetIncorporationIsSuccessful() throws ResourceNotFoundException {
+        // given
+        LimitedPartnershipIncorporationDto limitedPartnershipIncorporationDto = new LimitedPartnershipIncorporationDto();
+
+        limitedPartnershipIncorporationDto.setKind(LIMITED_PARTNERSHIP_REGISTRATION_KIND);
+
+        when(transaction.getId()).thenReturn(TRANSACTION_ID);
+        when(incorporationService.getIncorporation(transaction, SUBMISSION_ID, true)).thenReturn(limitedPartnershipIncorporationDto);
+
+        // when
+        var response = incorporationController.getIncorporation(
+                transaction,
+                SUBMISSION_ID,
+                true,
+                REQUEST_ID);
+
+        // then
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
+        assertEquals(limitedPartnershipIncorporationDto, response.getBody());
+        assertEquals(LIMITED_PARTNERSHIP_REGISTRATION_KIND, limitedPartnershipIncorporationDto.getKind());
+    }
+
+    @Test
+    void testNotFoundReturnedWhenGetIncorporationFailsToFindResource() throws ResourceNotFoundException {
+        // given
+        when(transaction.getId()).thenReturn(TRANSACTION_ID);
+        when(incorporationService.getIncorporation(transaction, SUBMISSION_ID, true)).thenThrow(new ResourceNotFoundException("error"));
+
+        // when
+        var response = incorporationController.getIncorporation(
+                transaction,
+                SUBMISSION_ID,
+                true,
+                REQUEST_ID);
+
+        // then
+        assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatusCode().value());
+        assertNull(response.getBody());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipIncorporationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipIncorporationMapperTest.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.limitedpartnershipsapi.mapper;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dao.IncorporationDataDao;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dao.LimitedPartnershipIncorporationDao;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipIncorporationDto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.companieshouse.limitedpartnershipsapi.service.LimitedPartnershipIncorporationService.LIMITED_PARTNERSHIP_REGISTRATION_KIND;
+
+class LimitedPartnershipIncorporationMapperTest {
+
+    @InjectMocks
+    LimitedPartnershipIncorporationMapper mapper;
+
+    @Test
+    void givenDao_whenMapsToDto_thenCorrect() {
+        // given
+        LimitedPartnershipIncorporationDao source = new LimitedPartnershipIncorporationDao();
+        IncorporationDataDao sourceData = new IncorporationDataDao();
+        sourceData.setKind(LIMITED_PARTNERSHIP_REGISTRATION_KIND);
+        source.setData(sourceData);
+
+        // when
+        LimitedPartnershipIncorporationDto destination = LimitedPartnershipIncorporationMapper.INSTANCE.daoToDto(source);
+
+        // then
+        assertEquals(LIMITED_PARTNERSHIP_REGISTRATION_KIND, destination.getKind());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipIncorporationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipIncorporationServiceTest.java
@@ -1,13 +1,5 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.LINK_SELF;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -15,8 +7,28 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.limitedpartnershipsapi.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.limitedpartnershipsapi.mapper.LimitedPartnershipIncorporationMapper;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dao.IncorporationDataDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.dao.LimitedPartnershipIncorporationDao;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.dto.LimitedPartnershipIncorporationDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.repository.LimitedPartnershipIncorporationRepository;
+import uk.gov.companieshouse.limitedpartnershipsapi.utils.TransactionUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.limitedpartnershipsapi.service.LimitedPartnershipIncorporationService.LIMITED_PARTNERSHIP_REGISTRATION_KIND;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.LINK_SELF;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_INCORPORATION;
 
 @ExtendWith(MockitoExtension.class)
 class LimitedPartnershipIncorporationServiceTest {
@@ -29,6 +41,12 @@ class LimitedPartnershipIncorporationServiceTest {
 
     @Captor
     private ArgumentCaptor<LimitedPartnershipIncorporationDao> incorporationCaptor;
+
+    @Mock
+    private TransactionUtils transactionUtils;
+
+    @Mock
+    private LimitedPartnershipIncorporationMapper mapper;
 
     private static final String USER_ID = "xbJf0l";
     private static final String SUBMISSION_ID = "abc-123";
@@ -54,9 +72,64 @@ class LimitedPartnershipIncorporationServiceTest {
         assertEquals(submissionUri, sentSubmissionUri);
     }
 
+    @Test
+    void testGetIncorporationTypeIsSuccessful() throws ResourceNotFoundException {
+        // given
+        Transaction transaction = buildTransaction();
+        LimitedPartnershipIncorporationDao limitedPartnershipIncorporationDao = createLimitedPartnershipIncorporationDao();
+        when(transactionUtils.isTransactionLinkedToLimitedPartnershipIncorporation(eq(transaction), any(String.class))).thenReturn(true);
+        when(repository.findById(SUBMISSION_ID)).thenReturn(Optional.of(limitedPartnershipIncorporationDao));
+        when(mapper.daoToDto(limitedPartnershipIncorporationDao)).thenReturn(createLimitedPartnershipIncorporationDto());
+
+        // when
+        var limitedPartnershipIncorporationDto = incorporationService.getIncorporation(transaction, SUBMISSION_ID, true);
+
+        // then
+        assertNotNull(limitedPartnershipIncorporationDto);
+        assertEquals(LIMITED_PARTNERSHIP_REGISTRATION_KIND, limitedPartnershipIncorporationDto.getKind());
+    }
+
+    @Test
+    void testGetIncorporationTypeReturnsNotFoundExceptionWhenNoLinkBetweenTransactionAndIncorporation() throws ResourceNotFoundException {
+        // given
+        Transaction transaction = buildTransaction();
+        when(transactionUtils.isTransactionLinkedToLimitedPartnershipIncorporation(eq(transaction), any(String.class))).thenReturn(false);
+
+        // when + then
+        assertThrows(ResourceNotFoundException.class, () -> incorporationService.getIncorporation(transaction, SUBMISSION_ID, true));
+    }
+
+    @Test
+    void testGetIncorporationTypeReturnsNotFoundExceptionWhenIncorporationNotFoundInMongo() {
+        final String INVALID_SUBMISSION_ID = "wrong-id";
+
+        // given
+        Transaction transaction = buildTransaction();
+        when(transactionUtils.isTransactionLinkedToLimitedPartnershipIncorporation(eq(transaction), any(String.class))).thenReturn(true);
+        when(repository.findById(INVALID_SUBMISSION_ID)).thenReturn(Optional.empty());
+
+        // when + then
+        assertThrows(ResourceNotFoundException.class, () -> incorporationService.getIncorporation(transaction, INVALID_SUBMISSION_ID, true));
+    }
+
     private LimitedPartnershipIncorporationDao createLimitedPartnershipIncorporationDao() {
         LimitedPartnershipIncorporationDao dao = new LimitedPartnershipIncorporationDao();
         dao.setId(SUBMISSION_ID);
+        IncorporationDataDao dataDao = new IncorporationDataDao();
+        dataDao.setKind(LIMITED_PARTNERSHIP_REGISTRATION_KIND);
+        dao.setData(dataDao);
         return dao;
+    }
+
+    private Transaction buildTransaction() {
+        Transaction transaction = new Transaction();
+        transaction.setId(TRANSACTION_ID);
+        return transaction;
+    }
+
+    private LimitedPartnershipIncorporationDto createLimitedPartnershipIncorporationDto() {
+        LimitedPartnershipIncorporationDto dto = new LimitedPartnershipIncorporationDto();
+        dto.setKind(LIMITED_PARTNERSHIP_REGISTRATION_KIND);
+        return dto;
     }
 }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-416

### Change description

* New controller method with 'include_sub_resources' query param
* New service method that maps the DAO to a DTO
* Validation checks added for 'resource not found'
* Unit tests added

TODO Returning all sub-resources and mapping the "etag" field

### Work checklist

* [ ] Bug fix
* [X] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.