### PR TITLE
LP-595 Ensure second nationality can be reset to 'null'

### DIFF
--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
@@ -116,7 +116,7 @@ class GeneralPartnerServiceUpdateTest {
     }
 
     @Test
-    void shouldFailUpdateIfNationalitiesAreSame() {
+    void shouldFailUpdateIfNationalitiesAreTheSame() {
         GeneralPartnerDao generalPartnerDao = createGeneralPartnerPersonDao();
 
         GeneralPartnerDataDto generalPartnerDataDto = new GeneralPartnerDataDto();
@@ -129,7 +129,44 @@ class GeneralPartnerServiceUpdateTest {
         );
 
         assertEquals("Second nationality must be different from the first", Objects.requireNonNull(exception.getBindingResult().getFieldError("nationality2")).getDefaultMessage());
+    }
 
+    @Test
+    void shouldAllowUpdateIfNationalitiesAreDifferent() throws Exception {
+        GeneralPartnerDao generalPartnerDao = createGeneralPartnerPersonDao();
+
+        GeneralPartnerDataDto generalPartnerDataDto = new GeneralPartnerDataDto();
+        generalPartnerDataDto.setNationality2(Nationality.NEW_ZEALANDER);
+
+        when(repository.findById(generalPartnerDao.getId())).thenReturn(Optional.of(generalPartnerDao));
+
+        service.updateGeneralPartner(GENERAL_PARTNER_ID, generalPartnerDataDto, REQUEST_ID, USER_ID);
+
+        verify(repository).save(submissionCaptor.capture());
+
+        GeneralPartnerDao sentSubmission = submissionCaptor.getValue();
+
+        assertEquals(Nationality.AMERICAN.getDescription(), sentSubmission.getData().getNationality1());
+        assertEquals(Nationality.NEW_ZEALANDER.getDescription(), sentSubmission.getData().getNationality2());
+    }
+
+    @Test
+    void shouldClearSecondNationalityIfBeingReset() throws Exception {
+        GeneralPartnerDao generalPartnerDao = createGeneralPartnerPersonDao();
+
+        GeneralPartnerDataDto generalPartnerDataDto = new GeneralPartnerDataDto();
+        generalPartnerDataDto.setNationality2(null);
+
+        when(repository.findById(generalPartnerDao.getId())).thenReturn(Optional.of(generalPartnerDao));
+
+        service.updateGeneralPartner(GENERAL_PARTNER_ID, generalPartnerDataDto, REQUEST_ID, USER_ID);
+
+        verify(repository).save(submissionCaptor.capture());
+
+        GeneralPartnerDao sentSubmission = submissionCaptor.getValue();
+
+        assertEquals(Nationality.AMERICAN.getDescription(), sentSubmission.getData().getNationality1());
+        assertEquals(null, sentSubmission.getData().getNationality2());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
@@ -84,6 +84,7 @@ class GeneralPartnerServiceUpdateTest {
     @Test
     void shouldUpdateTheDaoWithPrincipalOfficeAddress() throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
         GeneralPartnerDao generalPartnerDao = createGeneralPartnerPersonDao();
+        generalPartnerDao.getData().setNationality2(Nationality.GREENLANDIC.getDescription());
 
         AddressDto principalOfficeAddress = new AddressDto();
         principalOfficeAddress.setAddressLine1("DUNCALF STREET");
@@ -113,6 +114,9 @@ class GeneralPartnerServiceUpdateTest {
         assertEquals("STOKE-ON-TRENT", sentSubmission.getData().getPrincipalOfficeAddress().getLocality());
         assertEquals("ST6 3LJ", sentSubmission.getData().getPrincipalOfficeAddress().getPostalCode());
         assertEquals("2", sentSubmission.getData().getPrincipalOfficeAddress().getPremises());
+
+        // Ensure that second nationality isn't cleared if only address data is updated
+        assertEquals(Nationality.GREENLANDIC.getDescription(), sentSubmission.getData().getNationality2());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
@@ -120,6 +120,7 @@ class GeneralPartnerServiceUpdateTest {
         GeneralPartnerDao generalPartnerDao = createGeneralPartnerPersonDao();
 
         GeneralPartnerDataDto generalPartnerDataDto = new GeneralPartnerDataDto();
+        generalPartnerDataDto.setNationality1(Nationality.AMERICAN);
         generalPartnerDataDto.setNationality2(Nationality.AMERICAN);
 
         when(repository.findById(generalPartnerDao.getId())).thenReturn(Optional.of(generalPartnerDao));
@@ -136,6 +137,7 @@ class GeneralPartnerServiceUpdateTest {
         GeneralPartnerDao generalPartnerDao = createGeneralPartnerPersonDao();
 
         GeneralPartnerDataDto generalPartnerDataDto = new GeneralPartnerDataDto();
+        generalPartnerDataDto.setNationality1(Nationality.AMERICAN);
         generalPartnerDataDto.setNationality2(Nationality.NEW_ZEALANDER);
 
         when(repository.findById(generalPartnerDao.getId())).thenReturn(Optional.of(generalPartnerDao));
@@ -155,6 +157,7 @@ class GeneralPartnerServiceUpdateTest {
         GeneralPartnerDao generalPartnerDao = createGeneralPartnerPersonDao();
 
         GeneralPartnerDataDto generalPartnerDataDto = new GeneralPartnerDataDto();
+        generalPartnerDataDto.setNationality1(Nationality.AMERICAN);
         generalPartnerDataDto.setNationality2(null);
 
         when(repository.findById(generalPartnerDao.getId())).thenReturn(Optional.of(generalPartnerDao));


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-595

### Change description

* New code added to check for the relevant General Partner Update scenario and reset the second nationality to null, if appropriate
* Unit tests added

### Work checklist

* [ ] Bug fix
* [X] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.