### PR TITLE
Fix pipeline build-test-integration by adding missing makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ test: test-unit
 test-unit: clean
 	mvn test
 
+.PHONY: test-integration
+test-integration:
+
 .PHONY: package
 package:
 ifndef version

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ test-unit: clean
 	mvn test
 
 .PHONY: test-integration
-test-integration:
+test-integration: clean
+	mvn integration-test verify -Dskip.unit.tests=true
 
 .PHONY: package
 package:

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
         <encoder.version>1.3.1</encoder.version>
+        <skip.unit.tests>false</skip.unit.tests>
     </properties>
 
     <profiles>
@@ -194,6 +195,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <skipTests>${skip.unit.tests}</skipTests>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
### JIRA link
N/A


### Change description
The pipeline build-test-integration is failing as it can't find a makefile target for it.
This will add the missing target although it won't do anything as no integration tests.


### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.