### PR TITLE
LP-563 Add correct resume url for registration

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_LIMITED_PARTNERSHIP;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.LINK_SELF;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_PARTNERSHIP;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_RESUME_PARTNERSHIP;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_RESUME_REGISTRATION;
 
 @Service
 public class LimitedPartnershipService {
@@ -156,7 +156,7 @@ public class LimitedPartnershipService {
         transaction.setCompanyName(limitedPartnershipSubmissionDto.getData().getPartnershipName());
         transaction.setResources(Collections.singletonMap(submissionUri, limitedPartnershipResource));
 
-        final var resumeJourneyUri = String.format(URL_RESUME_PARTNERSHIP, transaction.getId(), submissionId);
+        final var resumeJourneyUri = String.format(URL_RESUME_REGISTRATION, transaction.getId(), submissionId);
         transaction.setResumeJourneyUri(resumeJourneyUri);
 
         transactionService.updateTransaction(transaction, loggingContext);

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
@@ -12,7 +12,7 @@ public class Constants {
     // URIs
     public static final String TRANSACTIONS_PRIVATE_API_URI_PREFIX = "/private/transactions/";
     public static final String URL_GET_PARTNERSHIP = "/transactions/%s/limited-partnership/partnership/%s";
-    public static final String URL_RESUME_PARTNERSHIP = "/limited-partnerships/transaction/%s/submission/%s/resume";
+    public static final String URL_RESUME_REGISTRATION = "/limited-partnerships/transaction/%s/submission/%s/which-type";
     public static final String URL_GET_INCORPORATION = "/transactions/%s/incorporation/limited-partnership/%s";
     public static final String URL_GET_LIMITED_PARTNER = "/transactions/%s/limited-partnership/limited-partner/%s";
     public static final String URL_GET_GENERAL_PARTNER = "/transactions/%s/limited-partnership/general-partner/%s";

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_LIMITED_PARTNERSHIP;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_PARTNERSHIP;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_RESUME_PARTNERSHIP;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_RESUME_REGISTRATION;
 
 @ExtendWith(MockitoExtension.class)
 class LimitedPartnershipServiceTest {
@@ -102,7 +102,7 @@ class LimitedPartnershipServiceTest {
         String submissionUri = String.format(URL_GET_PARTNERSHIP, transaction.getId(), limitedPartnershipSubmissionDao.getId());
         assertEquals(submissionUri, sentTransaction.getResources().get(submissionUri).getLinks().get("resource"));
         // assert resume link is correct
-        String resumeUri = String.format(URL_RESUME_PARTNERSHIP, transaction.getId(), limitedPartnershipSubmissionDao.getId());
+        String resumeUri = String.format(URL_RESUME_REGISTRATION, transaction.getId(), limitedPartnershipSubmissionDao.getId());
         assertEquals(resumeUri, sentTransaction.getResumeJourneyUri());
         // assert dao submission self link is correct
         LimitedPartnershipSubmissionDao sentSubmission = submissionCaptor.getValue();
@@ -111,7 +111,7 @@ class LimitedPartnershipServiceTest {
     }
 
     @Test
-    void givenTransactionAlreadyAssociatedWithAnLP_whenCreateLP_thenServiceExceptionThrown() throws ServiceException {
+    void givenTransactionAlreadyAssociatedWithAnLP_whenCreateLP_thenServiceExceptionThrown() {
         // given
         LimitedPartnershipSubmissionDto limitedPartnershipSubmissionDto = createDto();
 
@@ -127,7 +127,7 @@ class LimitedPartnershipServiceTest {
     }
 
     @Test
-    void giveInvalidSubmissionId_whenUpdateLp_ThenResourceNotFoundExceptionThrown() throws ResourceNotFoundException {
+    void giveInvalidSubmissionId_whenUpdateLp_ThenResourceNotFoundExceptionThrown() {
         // given
         Transaction transaction = buildTransaction();
         var limitedPartnershipPatchDto = new LimitedPartnershipPatchDto();
@@ -173,7 +173,7 @@ class LimitedPartnershipServiceTest {
     }
 
     @Test
-    void givenWrongSubmissionId_whenUpdateLP_thenServiceExceptionThrown() throws ServiceException {
+    void givenWrongSubmissionId_whenUpdateLP_thenServiceExceptionThrown() {
         // given
         when(repository.findById("wrong-id")).thenReturn(Optional.empty());
 
@@ -209,7 +209,7 @@ class LimitedPartnershipServiceTest {
     }
 
     @Test
-    void giveInvalidSubmissionId_whenGetLp_ThenResourceNotFoundExceptionThrown() throws ResourceNotFoundException {
+    void giveInvalidSubmissionId_whenGetLp_ThenResourceNotFoundExceptionThrown() {
         // given
         Transaction transaction = buildTransaction();
         when(transactionUtils.isTransactionLinkedToLimitedPartnershipSubmission(eq(transaction), any(String.class))).thenReturn(true);
@@ -220,7 +220,7 @@ class LimitedPartnershipServiceTest {
     }
 
     @Test
-    void giveSubmissionIdAndTransactionIdDoNotMatch_whenGetLp_ThenResourceNotFoundExceptionThrown() throws ResourceNotFoundException {
+    void giveSubmissionIdAndTransactionIdDoNotMatch_whenGetLp_ThenResourceNotFoundExceptionThrown() {
         // given
         Transaction transaction = buildTransaction();
         when(transactionUtils.isTransactionLinkedToLimitedPartnershipSubmission(eq(transaction), any(String.class))).thenReturn(false);
@@ -261,7 +261,7 @@ class LimitedPartnershipServiceTest {
     }
 
     @Test
-    void givenTransactionIdHasNoLpSubmission_whenGetLp_ThenResourceNotFoundExceptionThrown() throws ResourceNotFoundException {
+    void givenTransactionIdHasNoLpSubmission_whenGetLp_ThenResourceNotFoundExceptionThrown() {
         // given
         Transaction transaction = buildTransaction();
         when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)).thenReturn(false);
@@ -271,7 +271,7 @@ class LimitedPartnershipServiceTest {
     }
 
     @Test
-    void givenTransactionIdHasMultipleLpSubmissions_whenGetLp_ThenServiceExceptionThrown() throws ResourceNotFoundException {
+    void givenTransactionIdHasMultipleLpSubmissions_whenGetLp_ThenServiceExceptionThrown() {
         // given
         Transaction transaction = buildTransaction();
         LimitedPartnershipSubmissionDao lpDao1 = createDao();


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-563


### Change description
Change the url used for resuming a registration to be the first page on the registration journey


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.