### PR TITLE
LP-661 Add 'validation-status' endpoints and links

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/Constants.java
@@ -3,25 +3,30 @@ package uk.gov.companieshouse.limitedpartnershipsapi.utils;
 public class Constants {
     // Request header names
     public static final String ERIC_REQUEST_ID_KEY = "X-Request-Id";
+
     // URL path parameters
     public static final String URL_PARAM_TRANSACTION_ID = "transactionId";
     public static final String URL_PARAM_SUBMISSION_ID = "submissionId";
     public static final String URL_PARAM_FILING_RESOURCE_ID = "filingResourceId";
     public static final String URL_PARAM_GENERAL_PARTNER_ID = "generalPartnerId";
     public static final String TRANSACTION_KEY = "transaction";
+
     // URIs
     public static final String TRANSACTIONS_PRIVATE_API_URI_PREFIX = "/private/transactions/";
+    public static final String VALIDATION_STATUS_URI_SUFFIX = "/validation-status";
     public static final String URL_GET_PARTNERSHIP = "/transactions/%s/limited-partnership/partnership/%s";
     public static final String URL_RESUME_REGISTRATION = "/limited-partnerships/transaction/%s/submission/%s/which-type";
     public static final String URL_GET_INCORPORATION = "/transactions/%s/incorporation/limited-partnership/%s";
     public static final String URL_GET_LIMITED_PARTNER = "/transactions/%s/limited-partnership/limited-partner/%s";
     public static final String URL_GET_GENERAL_PARTNER = "/transactions/%s/limited-partnership/general-partner/%s";
+
     // Filings
     public static final String FILING_KIND_LIMITED_PARTNERSHIP = "limited-partnership";
     public static final String FILING_KIND_LIMITED_PARTNER = "limited-partnership#limited-partner";
     public static final String FILING_KIND_GENERAL_PARTNER = "limited-partnership#general-partner";
     public static final String LINK_SELF = "self";
     public static final String LINK_RESOURCE = "resource";
+
     // Validation rules
     public static final int MIN_SIZE = 1;
     public static final String MIN_SIZE_MESSAGE = "must be greater than {min}";
@@ -29,6 +34,7 @@ public class Constants {
     public static final int LONG_MAX_SIZE = 160;
     public static final String MAX_SIZE_MESSAGE = "must be less than {max}";
     public static final String REG_EXP_FOR_ALLOWED_CHARACTERS = "^[-,.:; 0-9A-Z&@$£¥€'\"«»?!/\\\\()\\[\\]{}<>*=#%+ÀÁÂÃÄÅĀĂĄÆǼÇĆĈĊČÞĎÐÈÉÊËĒĔĖĘĚĜĞĠĢĤĦÌÍÎÏĨĪĬĮİĴĶĹĻĽĿŁÑŃŅŇŊÒÓÔÕÖØŌŎŐǾŒŔŖŘŚŜŞŠŢŤŦÙÚÛÜŨŪŬŮŰŲŴẀẂẄỲÝŶŸŹŻŽa-zſƒǺàáâãäåāăąæǽçćĉċčþďðèéêëēĕėęěĝģğġĥħìíîïĩīĭįĵķĺļľŀłñńņňŋòóôõöøōŏőǿœŕŗřśŝşšţťŧùúûüũūŭůűųŵẁẃẅỳýŷÿźżž]*$";
+
     public static final String INVALID_CHARACTERS_MESSAGE = "must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes";
 
     private Constants() {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceTest.java
@@ -284,6 +284,24 @@ class LimitedPartnershipServiceTest {
         assertThrows(ServiceException.class, () -> service.getLimitedPartnership(transaction));
     }
 
+    @Test
+    void testValidateLimitedPartnershipWhenErrorsFound() throws ResourceNotFoundException {
+
+        // given
+        LimitedPartnershipSubmissionDto limitedPartnershipSubmissionDto = createDto();  // This DTO has no partnership type set, so that will produce one error when Java Bean validation is run
+        LimitedPartnershipSubmissionDao limitedPartnershipSubmissionDao = createDao();
+        Transaction transaction = buildTransaction();
+
+        when(transactionUtils.isTransactionLinkedToLimitedPartnershipSubmission(eq(transaction), any(String.class))).thenReturn(true);
+
+        when(repository.findById(SUBMISSION_ID)).thenReturn(Optional.of(limitedPartnershipSubmissionDao));
+        when(mapper.daoToDto(limitedPartnershipSubmissionDao)).thenReturn(limitedPartnershipSubmissionDto);
+
+        List<String> results = service.validateLimitedPartnership(transaction, SUBMISSION_ID);
+
+        assertEquals(2, results.size());
+    }
+
     private Transaction buildTransaction() {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-661

### Change description

* Only done for Limited Partnerships at present
* 'validation_status' resource link added to transaction
* New controller endpoint added
* Java Bean validation applied by service
* Hard-coded mandatory field error added
* Some unit-tests added

### Work checklist

* [ ] Bug fix
* [X] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.