### PR TITLE
LP-691 Ensure boolean values not lost on update

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/generalpartner/dto/GeneralPartnerDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/generalpartner/dto/GeneralPartnerDataDto.java
@@ -71,10 +71,10 @@ public class GeneralPartnerDataDto {
     private Nationality nationality2;
 
     @JsonProperty(NOT_DISQUALIFIED_STATEMENT_CHECKED_FIELD)
-    private boolean isNotDisqualifiedStatementChecked;
+    private Boolean isNotDisqualifiedStatementChecked;
 
     @JsonProperty(LEGAL_PERSONALITY_STATEMENT_CHECKED_FIELD)
-    private boolean isLegalPersonalityStatementChecked;
+    private Boolean isLegalPersonalityStatementChecked;
 
     @JsonProperty("date_effective_from")
     @JsonFormat(pattern = "yyyy-MM-dd")
@@ -182,19 +182,19 @@ public class GeneralPartnerDataDto {
         this.nationality2 = nationality2;
     }
 
-    public boolean isNotDisqualifiedStatementChecked() {
+    public Boolean isNotDisqualifiedStatementChecked() {
         return isNotDisqualifiedStatementChecked;
     }
 
-    public void setNotDisqualifiedStatementChecked(boolean notDisqualifiedStatementChecked) {
+    public void setNotDisqualifiedStatementChecked(Boolean notDisqualifiedStatementChecked) {
         isNotDisqualifiedStatementChecked = notDisqualifiedStatementChecked;
     }
 
-    public boolean isLegalPersonalityStatementChecked() {
+    public Boolean isLegalPersonalityStatementChecked() {
         return isLegalPersonalityStatementChecked;
     }
 
-    public void setLegalPersonalityStatementChecked(boolean legalPersonalityStatementChecked) {
+    public void setLegalPersonalityStatementChecked(Boolean legalPersonalityStatementChecked) {
         isLegalPersonalityStatementChecked = legalPersonalityStatementChecked;
     }
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceUpdateTest.java
@@ -2,6 +2,9 @@ package uk.gov.companieshouse.limitedpartnershipsapi.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -73,7 +76,7 @@ class GeneralPartnerServiceUpdateTest {
         dataDao.setLegalEntityRegisterName("UK Register");
         dataDao.setLegalEntityRegistrationLocation("United Kingdom");
         dataDao.setRegisteredCompanyNumber("12345678");
-        dataDao.setNotDisqualifiedStatementChecked(true);
+        dataDao.setLegalPersonalityStatementChecked(true);
 
         dao.setData(dataDao);
         dao.setId(GENERAL_PARTNER_ID);
@@ -198,4 +201,45 @@ class GeneralPartnerServiceUpdateTest {
         assertEquals("England", sentSubmission.getData().getLegalEntityRegistrationLocation());
     }
 
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(booleans = {true, false})
+    void shouldCorrectlyUpdateDisqualificationStatementCheckedValue(Boolean input) throws Exception {
+        GeneralPartnerDao currentlySavedPartnerDao = createGeneralPartnerPersonDao();
+
+        GeneralPartnerDataDto partnerDataDtoWithChanges = new GeneralPartnerDataDto();
+        partnerDataDtoWithChanges.setNotDisqualifiedStatementChecked(input);
+
+        when(repository.findById(currentlySavedPartnerDao.getId())).thenReturn(Optional.of(currentlySavedPartnerDao));
+
+        service.updateGeneralPartner(GENERAL_PARTNER_ID, partnerDataDtoWithChanges, REQUEST_ID, USER_ID);
+
+        verify(repository).findById(GENERAL_PARTNER_ID);
+        verify(repository).save(submissionCaptor.capture());
+
+        GeneralPartnerDao newlySavedPartnerDao = submissionCaptor.getValue();
+
+        assertEquals(input == null ? true : input, newlySavedPartnerDao.getData().isNotDisqualifiedStatementChecked());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(booleans = {true, false})
+    void shouldCorrectlyUpdateLegalPersonalityStatementCheckedValue(Boolean input) throws Exception {
+        GeneralPartnerDao currentlySavedPartnerDao = createGeneralPartnerLegalEntityDao();
+
+        GeneralPartnerDataDto partnerDataDtoWithChanges = new GeneralPartnerDataDto();
+        partnerDataDtoWithChanges.setLegalPersonalityStatementChecked(input);
+
+        when(repository.findById(currentlySavedPartnerDao.getId())).thenReturn(Optional.of(currentlySavedPartnerDao));
+
+        service.updateGeneralPartner(GENERAL_PARTNER_ID, partnerDataDtoWithChanges, REQUEST_ID, USER_ID);
+
+        verify(repository).findById(GENERAL_PARTNER_ID);
+        verify(repository).save(submissionCaptor.capture());
+
+        GeneralPartnerDao newlySavedPartnerDao = submissionCaptor.getValue();
+
+        assertEquals(input == null ? true : input, newlySavedPartnerDao.getData().isLegalPersonalityStatementChecked());
+    }
 }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-691

### Change description

* Use non-primitive Boolean datatype to allow for null values being submitted when General Partner is updated
* Unit tests added to check behaviour

### Work checklist

* [X] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.