### PR TITLE
lp-722: Map jurisdiction description to api constant keys

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipMapper.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipMapper.java
@@ -27,10 +27,10 @@ public interface LimitedPartnershipMapper {
     }
 
     default String mapJurisdictionToString(Jurisdiction jurisdiction) {
-        return jurisdiction.getDescription();
+        return jurisdiction.getApiKey();
     }
 
     default Jurisdiction mapJurisdictionToEnum(String jurisdiction) {
-        return jurisdiction != null ? Jurisdiction.fromDescription(jurisdiction) : null;
+        return jurisdiction != null ? Jurisdiction.fromApiKey(jurisdiction) : null;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/partnership/Jurisdiction.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/partnership/Jurisdiction.java
@@ -4,27 +4,27 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 
 public enum Jurisdiction {
-    ENGLAND_AND_WALES("England and Wales"),
-    NORTHERN_IRELAND("Northern Ireland"),
-    SCOTLAND("Scotland"),
+    ENGLAND_AND_WALES("england-wales"),
+    NORTHERN_IRELAND("northern-ireland"),
+    SCOTLAND("scotland"),
 
     @JsonEnumDefaultValue
     UNKNOWN("UNKNOWN");
 
-    private final String description;
+    private final String apiKey;
 
-    Jurisdiction(String description) {
-        this.description = description;
+    Jurisdiction(String apiKey) {
+        this.apiKey = apiKey;
     }
 
-    public String getDescription() {
-        return description;
+    public String getApiKey() {
+        return apiKey;
     }
 
     @JsonCreator
-    public static Jurisdiction fromDescription(String description) {
+    public static Jurisdiction fromApiKey(String apiKey) {
         for (Jurisdiction jurisdiction : Jurisdiction.values()) {
-            if (jurisdiction.getDescription().equalsIgnoreCase(description)) {
+            if (jurisdiction.getApiKey().equalsIgnoreCase(apiKey)) {
                 return jurisdiction;
             }
         }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/partnership/dto/DataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/partnership/dto/DataDto.java
@@ -107,7 +107,7 @@ public class DataDto {
     }
 
     public String getJurisdiction() {
-        return jurisdiction != null ? jurisdiction.getDescription() : null;
+        return jurisdiction != null ? jurisdiction.getApiKey() : null;
     }
 
     public void setJurisdiction(Jurisdiction jurisdiction) {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipMapperTest.java
@@ -71,17 +71,17 @@ class LimitedPartnershipMapperTest {
         // when
         String destinationData = LimitedPartnershipMapper.INSTANCE.mapJurisdictionToString(sourceData);
         // then
-        assertEquals(sourceData.getDescription(), destinationData);
+        assertEquals(sourceData.getApiKey(), destinationData);
     }
 
     @Test
     void givenJurisdictionString_whenMapsToEnum_thenCorrect() {
         // given
-        String sourceData = Jurisdiction.NORTHERN_IRELAND.getDescription();
+        String sourceData = Jurisdiction.NORTHERN_IRELAND.getApiKey();
         // when
         Jurisdiction destinationData = LimitedPartnershipMapper.INSTANCE.mapJurisdictionToEnum(sourceData);
         // then
-        assertEquals(sourceData, destinationData.getDescription());
+        assertEquals(sourceData, destinationData.getApiKey());
     }
 
     @Test
@@ -91,7 +91,7 @@ class LimitedPartnershipMapperTest {
         // when
         Jurisdiction destinationData = LimitedPartnershipMapper.INSTANCE.mapJurisdictionToEnum(invalidJurisdiction);
         // then
-        assertEquals(Jurisdiction.UNKNOWN.getDescription(), destinationData.getDescription());
+        assertEquals(Jurisdiction.UNKNOWN.getApiKey(), destinationData.getApiKey());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipPatchMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipPatchMapperTest.java
@@ -46,9 +46,9 @@ class LimitedPartnershipPatchMapperTest {
     @ParameterizedTest
     @CsvSource(value = {
             // Fields NOT present in the JSON - no update:
-            JSON_WITH_MISSING_FIELDS + "$ Asset Strippers $ test@test.com $ Scotland $ PFLP $ L.P.",
+            JSON_WITH_MISSING_FIELDS + "$ Asset Strippers $ test@test.com $ scotland $ PFLP $ L.P.",
             // Fields ARE present in the JSON - set the new string value:
-            JSON_WITH_VALID_FIELDS_ALL_PRESENT + "$ Asset Adders $ test@test.com $ Scotland $ PFLP $ L.P.",
+            JSON_WITH_VALID_FIELDS_ALL_PRESENT + "$ Asset Adders $ test@test.com $ scotland $ PFLP $ L.P.",
             // Enum fields are invalid in the JSON - set the 'UNKNOWN' value:
             JSON_WITH_INVALID_ENUM_VALUES + "$ Asset Adders $ test@test.com $ UNKNOWN $ UNKNOWN $ UNKNOWN"
     }, delimiter = '$')

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceValidateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceValidateTest.java
@@ -166,7 +166,7 @@ class LimitedPartnershipServiceValidateTest {
         dataDao.setPartnershipName("Asset Adders");
         dataDao.setNameEnding(PartnershipNameEnding.LIMITED_PARTNERSHIP.getDescription());
         dataDao.setEmail("some@where.com");
-        dataDao.setJurisdiction(Jurisdiction.ENGLAND_AND_WALES.getDescription());
+        dataDao.setJurisdiction(Jurisdiction.ENGLAND_AND_WALES.getApiKey());
         dataDao.setRegisteredOfficeAddress(createAddressDao());
         dataDao.setPrincipalPlaceOfBusinessAddress(createAddressDao());
         dao.setData(dataDao);


### PR DESCRIPTION
### JIRA link

[LP-722](https://companieshouse.atlassian.net/browse/LP-722)

### Change description

Switch Jurisdiction enum to use API constant keys.  These keys are then used within a change to chips filing consumer that will map these keys to their specific chips counterpart during processing.  

Relates to following web changes - https://github.com/companieshouse/limited-partnerships-web/pull/310

### Work checklist

* [X] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.

[LP-722]: https://companieshouse.atlassian.net/browse/LP-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ