### PR TITLE
LP-878 Remove costs links for sub-resources in Registration Journey

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerService.java
@@ -90,7 +90,6 @@ public class GeneralPartnerService {
         Map<String, String> linksMap = new HashMap<>();
         linksMap.put("resource", submissionUri);
         linksMap.put("validation_status", submissionUri + VALIDATION_STATUS_URI_SUFFIX);
-        linksMap.put("costs", submissionUri + "/costs");
 
         generalPartnerResource.setLinks(linksMap);
         generalPartnerResource.setKind(FILING_KIND_GENERAL_PARTNER);

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerService.java
@@ -92,7 +92,6 @@ public class LimitedPartnerService {
         Map<String, String> linksMap = new HashMap<>();
         linksMap.put("resource", submissionUri);
         linksMap.put("validation_status", submissionUri + VALIDATION_STATUS_URI_SUFFIX);
-        linksMap.put("costs", submissionUri + "/costs");
 
         limitedPartnerResource.setLinks(linksMap);
         limitedPartnerResource.setKind(FILING_KIND_LIMITED_PARTNER);

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipService.java
@@ -136,7 +136,6 @@ public class LimitedPartnershipService {
         Map<String, String> linksMap = new HashMap<>();
         linksMap.put("resource", submissionUri);
         linksMap.put("validation_status", submissionUri + VALIDATION_STATUS_URI_SUFFIX);
-        linksMap.put("costs", submissionUri + "/costs");
 
         limitedPartnershipResource.setLinks(linksMap);
         limitedPartnershipResource.setKind(FILING_KIND_LIMITED_PARTNERSHIP);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-878


### Change description
Remove temporary workaround to add costs links for all resources in a registration transaction. Code was added as a temporary workaround due to transaction api expecting cost endpoints resources when a payment block exists in a transaction.


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.