### PR TITLE
Updated Makefile for dependency check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,3 @@ sonar:
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
-
-.PHONY: security-check
-security-check:
-	mvn org.owasp:dependency-check-maven:check -DassemblyAnalyzerEnabled=false

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.11</version>
+        <version>2.1.12</version>
+        <relativePath/>
     </parent>
 
     <groupId>groupId</groupId>

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <!-- Empty file for now. Suppressions may be added later when analysing reported vulnerabilities.
-         See https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
-</suppressions>


### PR DESCRIPTION
JIRA-[CC-2264](https://companieshouse.atlassian.net/browse/CC-2264)

removed the dependency check section from the Makefile as a part of migrating to a centralized vulnerability scanning approach managed via the CI pipeline.
Updated parent pom to 2.1.12, use relativePath 2.1.12 brings in updated dependency-check settings.
Remove defunct suppress.xml.

[CC-2264]: https://companieshouse.atlassian.net/browse/CC-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ