### PR TITLE
LP-1012 fix for transition not disqualified statement

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/generalpartner/dao/GeneralPartnerDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/generalpartner/dao/GeneralPartnerDataDao.java
@@ -19,16 +19,14 @@ public class GeneralPartnerDataDao extends PartnerDataDao {
         this.serviceAddress = serviceAddress;
     }
 
-    // Legal Entity
-
     @Field("not_disqualified_statement_checked")
-    private boolean notDisqualifiedStatementChecked;
+    private Boolean notDisqualifiedStatementChecked;
 
-    public boolean getNotDisqualifiedStatementChecked() {
+    public Boolean getNotDisqualifiedStatementChecked() {
         return notDisqualifiedStatementChecked;
     }
 
-    public void setNotDisqualifiedStatementChecked(boolean notDisqualifiedStatementChecked) {
+    public void setNotDisqualifiedStatementChecked(Boolean notDisqualifiedStatementChecked) {
         this.notDisqualifiedStatementChecked = notDisqualifiedStatementChecked;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/generalpartner/dto/GeneralPartnerDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/generalpartner/dto/GeneralPartnerDataDto.java
@@ -1,9 +1,12 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.model.generalpartner.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.dto.AddressDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.dto.PartnerDataDto;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 public class GeneralPartnerDataDto extends PartnerDataDto {
 
@@ -25,6 +28,7 @@ public class GeneralPartnerDataDto extends PartnerDataDto {
     // Legal Entity
     public static final String NOT_DISQUALIFIED_STATEMENT_CHECKED_FIELD = "not_disqualified_statement_checked";
 
+    @JsonInclude(NON_NULL)
     @JsonProperty(NOT_DISQUALIFIED_STATEMENT_CHECKED_FIELD)
     private Boolean notDisqualifiedStatementChecked;
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerValidator.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerValidator.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.limitedpartnershipsapi.exception.ServiceException;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.dto.PartnerDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.generalpartner.dto.GeneralPartnerDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.generalpartner.dto.GeneralPartnerDto;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.incorporation.IncorporationKind;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,9 +62,13 @@ public class GeneralPartnerValidator extends PartnerValidator {
         } else if (generalPartnerDataDto.getForename() != null || generalPartnerDataDto.getSurname() != null) {
             checkNotNullPerson(CLASS_NAME, generalPartnerDataDto, bindingResult);
             isSecondNationalityDifferent(CLASS_NAME, generalPartnerDataDto, bindingResult);
-            if (Boolean.FALSE.equals(generalPartnerDataDto.getNotDisqualifiedStatementChecked())) {
-                addError(CLASS_NAME, GeneralPartnerDataDto.NOT_DISQUALIFIED_STATEMENT_CHECKED_FIELD, "Not Disqualified Statement must be checked", bindingResult);
+            if (!transaction.getFilingMode().equals(IncorporationKind.TRANSITION.getDescription())) {
+                var notDisqualifiedStatementChecked = generalPartnerDataDto.getNotDisqualifiedStatementChecked();
+                if (notDisqualifiedStatementChecked == null || Boolean.FALSE.equals(notDisqualifiedStatementChecked)) {
+                    addError(CLASS_NAME, GeneralPartnerDataDto.NOT_DISQUALIFIED_STATEMENT_CHECKED_FIELD, "Not Disqualified Statement must be checked", bindingResult);
+                }
             }
+
         } else {
             addError(CLASS_NAME, "", "Some fields are missing", bindingResult);
         }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/GeneralPartnerRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/GeneralPartnerRepositoryTest.java
@@ -44,9 +44,11 @@ class GeneralPartnerRepositoryTest {
 
         assertThat(result.get(0).getData().getLegalEntityName()).isEqualTo("My company ltd");
         assertThat(result.get(0).getData().getLegalForm()).isEqualTo("Limited Company");
+        assertThat(result.get(0).getData().getNotDisqualifiedStatementChecked()).isNull();
 
         assertThat(result.get(1).getData().getForename()).isEqualTo("John");
         assertThat(result.get(1).getData().getSurname()).isEqualTo("Doe");
+        assertThat(result.get(1).getData().getNotDisqualifiedStatementChecked()).isTrue();
     }
 
     private GeneralPartnerDao createGeneralPartnerPersonDao() {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceValidateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceValidateTest.java
@@ -200,11 +200,11 @@ class GeneralPartnerServiceValidateTest {
         when(repository.findById(generalPartnerDao.getId())).thenReturn(Optional.of(generalPartnerDao));
 
         // when
-        List<ValidationStatusError> results = service.validateGeneralPartner(transaction, GENERAL_PARTNER_ID);
+        List<ValidationStatusError> errors = service.validateGeneralPartner(transaction, GENERAL_PARTNER_ID);
 
         // then
         verify(repository).findById(generalPartnerDao.getId());
-        assertThat(results)
+        assertThat(errors)
                 .extracting(ValidationStatusError::getError, ValidationStatusError::getLocation)
                 .containsExactlyInAnyOrder(
                         tuple("Not Disqualified Statement must be checked", GeneralPartnerDataDto.NOT_DISQUALIFIED_STATEMENT_CHECKED_FIELD));
@@ -221,11 +221,11 @@ class GeneralPartnerServiceValidateTest {
         when(companyProfileApi.getDateOfCreation()).thenReturn(LocalDate.of(2022, 1, 3));
 
         // when
-        List<ValidationStatusError> results = service.validateGeneralPartner(transaction, GENERAL_PARTNER_ID);
+        List<ValidationStatusError> errors = service.validateGeneralPartner(transaction, GENERAL_PARTNER_ID);
 
         // then
         verify(repository).findById(generalPartnerDao.getId());
-        assertThat(results).isEmpty();
+        assertThat(errors).isEmpty();
     }
 
     private GeneralPartnerDao createPersonDao() {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1012


### Change description
Transition journey doesn't include a 'not disqualified' question, and was failing validation because it was stored as 'false' in MongoDb.
Making the field optional with a Boolean instead of boolean to fix.


### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.