### PR TITLE
LP-726 Change interceptor to allow GET on closed transaction

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfig.java
@@ -10,9 +10,9 @@ import uk.gov.companieshouse.api.interceptor.ClosedTransactionInterceptor;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
+import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.AllowedTransactionStatusInterceptor;
 import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.CustomUserAuthenticationInterceptor;
 import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.LoggingInterceptor;
-import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.OpenOrClosedPendingPaymentTransactionInterceptor;
 
 import java.util.stream.Stream;
 
@@ -52,16 +52,16 @@ public class InterceptorConfig implements WebMvcConfigurer {
     private final CustomUserAuthenticationInterceptor customUserAuthenticationInterceptor;
     private final InternalUserInterceptor internalUserInterceptor;
     private final ClosedTransactionInterceptor closedTransactionInterceptor = new ClosedTransactionInterceptor();
-    private final OpenOrClosedPendingPaymentTransactionInterceptor openOrClosedPendingPaymentTransactionInterceptor;
+    private final AllowedTransactionStatusInterceptor allowedTransactionStatusInterceptor;
 
     public InterceptorConfig(LoggingInterceptor loggingInterceptor,
                              CustomUserAuthenticationInterceptor customUserAuthenticationInterceptor,
                              InternalUserInterceptor internalUserInterceptor,
-                             OpenOrClosedPendingPaymentTransactionInterceptor openOrClosedPendingPaymentTransactionInterceptor) {
+                             AllowedTransactionStatusInterceptor allowedTransactionStatusInterceptor) {
         this.loggingInterceptor = loggingInterceptor;
         this.customUserAuthenticationInterceptor = customUserAuthenticationInterceptor;
         this.internalUserInterceptor = internalUserInterceptor;
-        this.openOrClosedPendingPaymentTransactionInterceptor = openOrClosedPendingPaymentTransactionInterceptor;
+        this.allowedTransactionStatusInterceptor = allowedTransactionStatusInterceptor;
     }
 
     /**
@@ -83,7 +83,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
                 .addPathPatterns(INTERNAL_ENDPOINTS);
         registry.addInterceptor(closedTransactionInterceptor)
                 .addPathPatterns(FILINGS_ENDPOINTS);
-        registry.addInterceptor(openOrClosedPendingPaymentTransactionInterceptor)
+        registry.addInterceptor(allowedTransactionStatusInterceptor)
                 .addPathPatterns(CRUD_AND_COST_ENDPOINTS)
                 .excludePathPatterns(COST_ENDPOINTS);
     }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/ControllerEndpointInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/ControllerEndpointInterceptorTest.java
@@ -23,9 +23,9 @@ import uk.gov.companieshouse.limitedpartnershipsapi.controller.IncorporationCont
 import uk.gov.companieshouse.limitedpartnershipsapi.controller.LimitedPartnerController;
 import uk.gov.companieshouse.limitedpartnershipsapi.controller.PartnershipController;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.GlobalExceptionHandler;
+import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.AllowedTransactionStatusInterceptor;
 import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.CustomUserAuthenticationInterceptor;
 import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.LoggingInterceptor;
-import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.OpenOrClosedPendingPaymentTransactionInterceptor;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.CostsService;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.FilingsService;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.GeneralPartnerService;
@@ -102,14 +102,14 @@ class ControllerEndpointInterceptorTest {
     private InternalUserInterceptor internalUserInterceptor;
 
     @MockitoBean
-    private OpenOrClosedPendingPaymentTransactionInterceptor openOrClosedPendingPaymentTransactionInterceptor;
+    private AllowedTransactionStatusInterceptor allowedTransactionStatusInterceptor;
 
     @BeforeEach
     void setUp() {
         when(loggingInterceptor.preHandle(any(), any(), any())).thenReturn(true);
         when(customUserAuthenticationInterceptor.preHandle(any(), any(), any())).thenReturn(true);
         when(transactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
-        when(openOrClosedPendingPaymentTransactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        when(allowedTransactionStatusInterceptor.preHandle(any(), any(), any())).thenReturn(true);
 
         httpHeaders = new HttpHeaders();
         httpHeaders.add("ERIC-Access-Token", "passthrough");

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfigTest.java
@@ -12,9 +12,9 @@ import uk.gov.companieshouse.api.interceptor.ClosedTransactionInterceptor;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
+import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.AllowedTransactionStatusInterceptor;
 import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.CustomUserAuthenticationInterceptor;
 import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.LoggingInterceptor;
-import uk.gov.companieshouse.limitedpartnershipsapi.interceptor.OpenOrClosedPendingPaymentTransactionInterceptor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -41,7 +41,7 @@ class InterceptorConfigTest {
     private InternalUserInterceptor internalUserInterceptor;
 
     @Mock
-    private OpenOrClosedPendingPaymentTransactionInterceptor openOrClosedPendingPaymentTransactionInterceptor;
+    private AllowedTransactionStatusInterceptor allowedTransactionStatusInterceptor;
 
 
     @InjectMocks
@@ -61,7 +61,7 @@ class InterceptorConfigTest {
         inOrder.verify(interceptorRegistry).addInterceptor(any(TransactionInterceptor.class));
         inOrder.verify(interceptorRegistry).addInterceptor(internalUserInterceptor);
         inOrder.verify(interceptorRegistry).addInterceptor(any(ClosedTransactionInterceptor.class));
-        inOrder.verify(interceptorRegistry).addInterceptor(openOrClosedPendingPaymentTransactionInterceptor);
+        inOrder.verify(interceptorRegistry).addInterceptor(allowedTransactionStatusInterceptor);
 
         verify(interceptorRegistry, times(7)).addInterceptor(any());
     }


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-726


### Change description
Update the interceptor to allow a GET request when transaction is closed, to allow us to render the confirmation screen after payment.


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.