### PR TITLE
LP-468 Transaction Util changes removed word submit

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerService.java
@@ -215,7 +215,7 @@ public class GeneralPartnerService {
         String transactionId = transaction.getId();
         var submissionUri = String.format(URL_GET_GENERAL_PARTNER, transactionId, generalPartnerId);
 
-        if (!transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, submissionUri, FILING_KIND_GENERAL_PARTNER)) {
+        if (!transactionUtils.isTransactionLinkedToPartner(transaction, submissionUri, FILING_KIND_GENERAL_PARTNER)) {
             throw new ResourceNotFoundException(String.format(
                     "Transaction id: %s does not have a resource that matches general partner id: %s", transactionId, generalPartnerId));
         }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerService.java
@@ -217,7 +217,7 @@ public class LimitedPartnerService {
         String transactionId = transaction.getId();
         var submissionUri = String.format(URL_GET_LIMITED_PARTNER, transactionId, limitedPartnerId);
 
-        if (!transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, submissionUri, FILING_KIND_LIMITED_PARTNER)) {
+        if (!transactionUtils.isTransactionLinkedToPartner(transaction, submissionUri, FILING_KIND_LIMITED_PARTNER)) {
             throw new ResourceNotFoundException(String.format(
                     "Transaction id: %s does not have a resource that matches limited partner id: %s", transactionId, limitedPartnerId));
         }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipService.java
@@ -201,7 +201,7 @@ public class LimitedPartnershipService {
     }
 
     public LimitedPartnershipDto getLimitedPartnership(Transaction transaction) throws ServiceException {
-        if (!transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)) {
+        if (!transactionUtils.doesTransactionHaveALimitedPartnership(transaction)) {
             throw new ResourceNotFoundException(String.format(
                     "Transaction id: %s does not have a limited partnership resource", transaction.getId()));
         }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/TransactionUtils.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/TransactionUtils.java
@@ -20,7 +20,7 @@ public class TransactionUtils {
         return doChecks(transaction, limitedPartnershipSubmissionSelfLink, FILING_KIND_LIMITED_PARTNERSHIP);
     }
 
-    public boolean doesTransactionHaveALimitedPartnershipSubmission(Transaction transaction) {
+    public boolean doesTransactionHaveALimitedPartnership(Transaction transaction) {
         if (Objects.isNull(transaction) || Objects.isNull(transaction.getResources())) {
             return false;
         }
@@ -36,7 +36,7 @@ public class TransactionUtils {
         return doIncorporationChecks(transaction, limitedPartnershipIncorporationSelfLink);
     }
 
-    public boolean isTransactionLinkedToPartnerSubmission(Transaction transaction, String partnerSubmissionSelfLink, String kind) {
+    public boolean isTransactionLinkedToPartner(Transaction transaction, String partnerSubmissionSelfLink, String kind) {
         return doChecks(transaction, partnerSubmissionSelfLink, kind);
     }
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerUpdateTest.java
@@ -445,7 +445,7 @@ class GeneralPartnerControllerUpdateTest {
         when(generalPartnerRepository.save(any())).thenReturn(generalPartnerDao);
         when(generalPartnerRepository.findById(GENERAL_PARTNER_ID)).thenReturn(Optional.of(generalPartnerDao));
 
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(any(), any(), any())).thenReturn(true);
+        when(transactionUtils.isTransactionLinkedToPartner(any(), any(), any())).thenReturn(true);
     }
 
     private void mocks() {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerValidationTest.java
@@ -266,7 +266,7 @@ class GeneralPartnerControllerValidationTest {
         when(repository.save(any())).thenReturn(generalPartnerDao);
         when(repository.findById(GENERAL_PARTNER_ID)).thenReturn(Optional.of(generalPartnerDao));
 
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(any(), any(), any())).thenReturn(true);
+        when(transactionUtils.isTransactionLinkedToPartner(any(), any(), any())).thenReturn(true);
     }
 
     private void mocks() {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerValidationTest.java
@@ -144,7 +144,7 @@ class IncorporationControllerValidationTest {
     class ValidateIncorporation {
         @Test
         void shouldReturn200IfNoErrors() throws Exception {
-            when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(any())).thenReturn(true);
+            when(transactionUtils.doesTransactionHaveALimitedPartnership(any())).thenReturn(true);
             when(limitedPartnershipRepository.findByTransactionId(any())).thenReturn(List.of(new LimitedPartnershipBuilder().withAddresses().buildDao()));
             when(generalPartnerRepository.findAllByTransactionIdOrderByUpdatedAtDesc(any())).thenReturn(List.of(new GeneralPartnerBuilder().personDao()));
             when(limitedPartnerRepository.findAllByTransactionIdOrderByUpdatedAtDesc(any())).thenReturn(List.of(new LimitedPartnerBuilder().personDao()));
@@ -165,7 +165,7 @@ class IncorporationControllerValidationTest {
             generalPartnerDao.getData().setForename("");
             generalPartnerDao.getData().setNationality1("UNKNOWN");
 
-            when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(any())).thenReturn(true);
+            when(transactionUtils.doesTransactionHaveALimitedPartnership(any())).thenReturn(true);
             when(limitedPartnershipRepository.findByTransactionId(any())).thenReturn(List.of(new LimitedPartnershipBuilder().withAddresses().buildDao()));
             when(generalPartnerRepository.findAllByTransactionIdOrderByUpdatedAtDesc(any())).thenReturn(List.of(generalPartnerDao));
             when(limitedPartnerRepository.findAllByTransactionIdOrderByUpdatedAtDesc(any())).thenReturn(List.of(new LimitedPartnerBuilder().personDao()));
@@ -186,7 +186,7 @@ class IncorporationControllerValidationTest {
 
         @Test
         void shouldReturn200AndErrorDetailsIfInsufficientNumberOfPartners() throws Exception {
-            when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(any())).thenReturn(true);
+            when(transactionUtils.doesTransactionHaveALimitedPartnership(any())).thenReturn(true);
             when(limitedPartnershipRepository.findByTransactionId(any())).thenReturn(List.of(new LimitedPartnershipBuilder().withAddresses().buildDao()));
             when(generalPartnerRepository.findAllByTransactionIdOrderByUpdatedAtDesc(any())).thenReturn(Collections.emptyList());
             when(limitedPartnerRepository.findAllByTransactionIdOrderByUpdatedAtDesc(any())).thenReturn(Collections.emptyList());

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
@@ -608,7 +608,7 @@ class LimitedPartnerControllerUpdateTest {
         when(limitedPartnerRepository.findById(LIMITED_PARTNER_ID)).thenReturn(Optional.of(limitedPartnerDao));
         doNothing().when(limitedPartnerRepository).deleteById(LIMITED_PARTNER_ID);
 
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(any(), any(), any())).thenReturn(true);
+        when(transactionUtils.isTransactionLinkedToPartner(any(), any(), any())).thenReturn(true);
 
         LimitedPartnershipDto limitedPartnershipDto = new LimitedPartnershipDto();
         DataDto dataDto = new DataDto();

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerValidationTest.java
@@ -282,7 +282,7 @@ class LimitedPartnerControllerValidationTest {
         when(limitedPartnerRepository.save(any())).thenReturn(limitedPartnerDao);
         when(limitedPartnerRepository.findById(LIMITED_PARTNER_ID)).thenReturn(Optional.of(limitedPartnerDao));
 
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(any(), any(), any())).thenReturn(true);
+        when(transactionUtils.isTransactionLinkedToPartner(any(), any(), any())).thenReturn(true);
 
         mockLimitedPartnershipService(PartnershipType.LP);
     }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerValidationTest.java
@@ -808,7 +808,7 @@ class PartnershipControllerValidationTest {
         when(repository.findById(SUBMISSION_ID)).thenReturn(Optional.of(limitedPartnershipDao));
         when(repository.findByTransactionId(TRANSACTION_ID)).thenReturn(List.of(limitedPartnershipDao));
 
-        when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(any())).thenReturn(true);
+        when(transactionUtils.doesTransactionHaveALimitedPartnership(any())).thenReturn(true);
     }
 
     private void mocks() {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceTest.java
@@ -85,7 +85,7 @@ class GeneralPartnerServiceTest {
                 .thenReturn(Optional.of(dao));
 
         when(mapper.daoToDto(dao)).thenReturn(new GeneralPartnerBuilder().personDto());
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(any(), anyString(), anyString()))
+        when(transactionUtils.isTransactionLinkedToPartner(any(), anyString(), anyString()))
                 .thenReturn(true);
 
         var dto = generalPartnerService.getGeneralPartner(transaction, SUBMISSION_ID);
@@ -97,14 +97,14 @@ class GeneralPartnerServiceTest {
     void testGetGeneralPartnerNotFound() {
         when(repository.findById(SUBMISSION_ID))
                 .thenReturn(Optional.empty());
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(eq(transaction), any(String.class), any(String.class))).thenReturn(true);
+        when(transactionUtils.isTransactionLinkedToPartner(eq(transaction), any(String.class), any(String.class))).thenReturn(true);
         ResourceNotFoundException resourceNotFoundException = assertThrows(ResourceNotFoundException.class, () -> generalPartnerService.getGeneralPartner(transaction, SUBMISSION_ID));
         assertEquals("General partner submission with id " + SUBMISSION_ID + " not found", resourceNotFoundException.getMessage());
     }
 
     @Test
     void testGetGeneralPartnerLinkFails() {
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(eq(transaction), any(String.class), any(String.class)))
+        when(transactionUtils.isTransactionLinkedToPartner(eq(transaction), any(String.class), any(String.class)))
                 .thenReturn(false);
         ResourceNotFoundException resourceNotFoundException = assertThrows(ResourceNotFoundException.class, () -> generalPartnerService.getGeneralPartner(transaction, SUBMISSION_ID));
         assertEquals(String.format("Transaction id: %s does not have a resource that matches general partner id: %s", transaction.getId(), SUBMISSION_ID), resourceNotFoundException.getMessage());

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerServiceTest.java
@@ -76,7 +76,7 @@ class LimitedPartnerServiceTest {
                 .thenReturn(Optional.of(dao));
 
         when(mapper.daoToDto(dao)).thenReturn(createDto());
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(any(Transaction.class), any(String.class), any(String.class))).thenReturn(true)
+        when(transactionUtils.isTransactionLinkedToPartner(any(Transaction.class), any(String.class), any(String.class))).thenReturn(true)
                 .thenReturn(true);
 
         var dto = limitedPartnerService.getLimitedPartner(buildTransaction(), SUBMISSION_ID);
@@ -91,7 +91,7 @@ class LimitedPartnerServiceTest {
 
         when(repository.findById(SUBMISSION_ID))
                 .thenReturn(Optional.empty());
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(eq(transaction), any(String.class), any(String.class))).thenReturn(true);
+        when(transactionUtils.isTransactionLinkedToPartner(eq(transaction), any(String.class), any(String.class))).thenReturn(true);
         ResourceNotFoundException resourceNotFoundException = assertThrows(ResourceNotFoundException.class, () -> limitedPartnerService.getLimitedPartner(transaction, SUBMISSION_ID));
         assertEquals("Limited partner submission with id abc-123 not found", resourceNotFoundException.getMessage());
     }
@@ -164,7 +164,7 @@ class LimitedPartnerServiceTest {
         String submissionId = "sub-456";
 
         // Mock the behavior of isTransactionLinkedToLimitedPartnerSubmission method
-        when(transactionUtils.isTransactionLinkedToPartnerSubmission(eq(transaction), any(String.class), any(String.class))).thenReturn(false);
+        when(transactionUtils.isTransactionLinkedToPartner(eq(transaction), any(String.class), any(String.class))).thenReturn(false);
 
         // Act & Assert
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceTest.java
@@ -283,7 +283,7 @@ class LimitedPartnershipServiceTest {
         LimitedPartnershipDao limitedPartnershipDao = createDao();
         Transaction transaction = buildTransaction();
 
-        when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)).thenReturn(true);
+        when(transactionUtils.doesTransactionHaveALimitedPartnership(transaction)).thenReturn(true);
         when(repository.findByTransactionId(transaction.getId())).thenReturn(List.of(
                 limitedPartnershipDao));
         when(mapper.daoToDto(limitedPartnershipDao)).thenReturn(limitedPartnershipDto);
@@ -301,7 +301,7 @@ class LimitedPartnershipServiceTest {
     void givenInvalidTransactionId_whenGetLp_ThenResourceNotFoundExceptionThrown() {
         // given
         Transaction transaction = buildTransaction();
-        when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)).thenReturn(true);
+        when(transactionUtils.doesTransactionHaveALimitedPartnership(transaction)).thenReturn(true);
         when(repository.findByTransactionId(transaction.getId())).thenReturn(Collections.emptyList());
 
         // when + then
@@ -312,7 +312,7 @@ class LimitedPartnershipServiceTest {
     void givenTransactionIdHasNoLpSubmission_whenGetLp_ThenResourceNotFoundExceptionThrown() {
         // given
         Transaction transaction = buildTransaction();
-        when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)).thenReturn(false);
+        when(transactionUtils.doesTransactionHaveALimitedPartnership(transaction)).thenReturn(false);
 
         // when + then
         assertThrows(ResourceNotFoundException.class, () -> service.getLimitedPartnership(transaction));
@@ -325,7 +325,7 @@ class LimitedPartnershipServiceTest {
         LimitedPartnershipDao lpDao1 = createDao();
         LimitedPartnershipDao lpDao2 = createDao();
 
-        when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)).thenReturn(true);
+        when(transactionUtils.doesTransactionHaveALimitedPartnership(transaction)).thenReturn(true);
         when(repository.findByTransactionId(transaction.getId())).thenReturn(List.of(lpDao1, lpDao2));
 
         // when + then
@@ -339,7 +339,7 @@ class LimitedPartnershipServiceTest {
         LimitedPartnershipDao limitedPartnershipSubmissionDao = createDao();
         Transaction transaction = buildTransaction();
 
-        when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)).thenReturn(true);
+        when(transactionUtils.doesTransactionHaveALimitedPartnership(transaction)).thenReturn(true);
         when(repository.findByTransactionId(TRANSACTION_ID)).thenReturn(List.of(limitedPartnershipSubmissionDao));
         when(mapper.daoToDto(limitedPartnershipSubmissionDao)).thenReturn(limitedPartnershipSubmissionDto);
         when(limitedPartnershipValidator.validateFull(limitedPartnershipSubmissionDto, REGISTRATION)).thenReturn(new ArrayList<>());
@@ -358,7 +358,7 @@ class LimitedPartnershipServiceTest {
         LimitedPartnershipDao limitedPartnershipSubmissionDao = createDao();
         Transaction transaction = buildTransaction();
 
-        when(transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction)).thenReturn(true);
+        when(transactionUtils.doesTransactionHaveALimitedPartnership(transaction)).thenReturn(true);
         when(repository.findByTransactionId(TRANSACTION_ID)).thenReturn(List.of(limitedPartnershipSubmissionDao));
         when(mapper.daoToDto(limitedPartnershipSubmissionDao)).thenReturn(limitedPartnershipSubmissionDto);
         List<ValidationStatusError> errorsList = new ArrayList<>();

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/TransactionUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/utils/TransactionUtilsTest.java
@@ -95,7 +95,7 @@ class TransactionUtilsTest {
         transactionResources.put(LIMITED_PARTNERSHIP_SELF_LINK, limitedPartnershipResource);
         when(transaction.getResources()).thenReturn(transactionResources);
         // when
-        var result = transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction);
+        var result = transactionUtils.doesTransactionHaveALimitedPartnership(transaction);
         // then
         assertTrue(result);
     }
@@ -103,7 +103,7 @@ class TransactionUtilsTest {
     @Test
     void givenTransactionHasALimitedPartnershipCalledWithNullTransaction_thenReturnFalse() {
         // when
-        var result = transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(null);
+        var result = transactionUtils.doesTransactionHaveALimitedPartnership(null);
         // then
         assertFalse(result);
     }
@@ -117,7 +117,7 @@ class TransactionUtilsTest {
         transactionResources.put(LIMITED_PARTNERSHIP_SELF_LINK, limitedPartnershipResource);
         when(transaction.getResources()).thenReturn(transactionResources);
         // when
-        var result = transactionUtils.doesTransactionHaveALimitedPartnershipSubmission(transaction);
+        var result = transactionUtils.doesTransactionHaveALimitedPartnership(transaction);
         // then
         assertFalse(result);
     }
@@ -152,7 +152,7 @@ class TransactionUtilsTest {
         transactionResources.put(LIMITED_PARTNER_SELF_LINK, limitedPartnerResource);
         when(transaction.getResources()).thenReturn(transactionResources);
         // when
-        var result = transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, LIMITED_PARTNER_SELF_LINK, FILING_KIND_LIMITED_PARTNER);
+        var result = transactionUtils.isTransactionLinkedToPartner(transaction, LIMITED_PARTNER_SELF_LINK, FILING_KIND_LIMITED_PARTNER);
         // then
         assertTrue(result);
     }
@@ -160,7 +160,7 @@ class TransactionUtilsTest {
     @Test
     void givenALimitedPartnerSelfLinkIsBlank_thenReturnFalse() {
         // when
-        var result = transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, "", FILING_KIND_LIMITED_PARTNER);
+        var result = transactionUtils.isTransactionLinkedToPartner(transaction, "", FILING_KIND_LIMITED_PARTNER);
         // then
         assertFalse(result);
     }
@@ -170,7 +170,7 @@ class TransactionUtilsTest {
         // given
         when(transaction.getResources()).thenReturn(null);
         // when
-        var result = transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, LIMITED_PARTNER_SELF_LINK, FILING_KIND_LIMITED_PARTNER);
+        var result = transactionUtils.isTransactionLinkedToPartner(transaction, LIMITED_PARTNER_SELF_LINK, FILING_KIND_LIMITED_PARTNER);
         // then
         assertFalse(result);
     }
@@ -187,7 +187,7 @@ class TransactionUtilsTest {
         generalPartnerResource.setLinks(generalPartnerResourceLinks);
 
         when(transaction.getResources()).thenReturn(transactionResources);
-        var result = transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, GENERAL_PARTNER_SELF_LINK, FILING_KIND_GENERAL_PARTNER);
+        var result = transactionUtils.isTransactionLinkedToPartner(transaction, GENERAL_PARTNER_SELF_LINK, FILING_KIND_GENERAL_PARTNER);
 
         assertTrue(result);
     }
@@ -204,21 +204,21 @@ class TransactionUtilsTest {
         generalPartnerResource.setLinks(generalPartnerResourceLinks);
 
         when(transaction.getResources()).thenReturn(transactionResources);
-        var result = transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, GENERAL_PARTNER_SELF_LINK, FILING_KIND_GENERAL_PARTNER);
+        var result = transactionUtils.isTransactionLinkedToPartner(transaction, GENERAL_PARTNER_SELF_LINK, FILING_KIND_GENERAL_PARTNER);
 
         assertFalse(result);
     }
 
     @Test
     void givenGeneralPartnerSelfLinkIsBlank_thenReturnFalse() {
-        var result = transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, "", FILING_KIND_GENERAL_PARTNER);
+        var result = transactionUtils.isTransactionLinkedToPartner(transaction, "", FILING_KIND_GENERAL_PARTNER);
         assertFalse(result);
     }
 
     @Test
     void givenGeneralPartnerTransactionIsNull_thenReturnFalse() {
         when(transaction.getResources()).thenReturn(null);
-        var result = transactionUtils.isTransactionLinkedToPartnerSubmission(transaction, GENERAL_PARTNER_SELF_LINK, FILING_KIND_GENERAL_PARTNER);
+        var result = transactionUtils.isTransactionLinkedToPartner(transaction, GENERAL_PARTNER_SELF_LINK, FILING_KIND_GENERAL_PARTNER);
         assertFalse(result);
     }
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LP-468


### Change description

- No changes for point 3 on the ticket "Remove the word ‘Submission’ out of the created response LP and GP DTOs" - o instances of the word "Submit" were found in the dtos.

- Removed instances of the word "Submit" from method names from the existing TransactionUtils as specified in point 1. and from all locations that call these methods.

### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.