### PR TITLE
LP-968 Remove TODO for patch validation on limited partner

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerValidator.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnerValidator.java
@@ -143,7 +143,6 @@ public class LimitedPartnerValidator extends PartnerValidator {
         BindingResult bindingResult = new BeanPropertyBindingResult(limitedPartnerDto, LimitedPartnerDataDto.class.getName());
 
         dtoValidation(CLASS_NAME, limitedPartnerDto, bindingResult);
-        // TODO validate all mandatory fields are supplied in the Patch
 
         isSecondNationalityDifferent(CLASS_NAME, limitedPartnerDto.getData(), bindingResult);
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-968


### Change description
I originally added a TODO to add validation to include mandatory fields in the limited partner Patch.
Looking into how an API patch should work:

> A PATCH request in an API is used to make partial updates to a resource—just change what’s needed without replacing the whole thing.

Which is what we can currently do. If I were to add the validation to include mandatory fields then the each patch will require all the mandatory fields to be supplied which goes against how a Patch should work.

So I'll remove the TODO as I don't think I was correct in adding it in the first place.

### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.