### PR TITLE
lp-1143 : post-transition - name validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipValidator.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipValidator.java
@@ -81,6 +81,21 @@ public class LimitedPartnershipValidator {
             }
         }
 
+        if (limitedPartnershipDto.getData().getKind().equals(PartnershipKind.UPDATE_PARTNERSHIP_NAME.getDescription())) {
+            Set<ConstraintViolation<LimitedPartnershipDto>> violations = validator.validate(limitedPartnershipDto);
+
+            if (!violations.isEmpty()) {
+                violations.forEach(violation ->
+                        errorsList.add(createValidationStatusError(violation.getMessage(), violation.getPropertyPath().toString()))
+                );
+            }
+
+            if (limitedPartnershipDto.getData().getPartnershipName() == null) {
+                errorsList.add(createValidationStatusError("Name ending is required",
+                        "data.nameEnding"));
+            }
+        }
+
         return errorsList;
     }
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerUpdateTest.java
@@ -115,6 +115,36 @@ class PartnershipControllerUpdateTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    void UpdateNameShouldReturn200() throws Exception {
+        mocks();
+
+        String body = "{ \"partnership_name\" : \"Test name\", \"name_ending\" : \"LP\" }";
+
+        mockMvc.perform(patch(PARTNERSHIP_PATCH_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .headers(httpHeaders)
+                        .requestAttr("transaction", transaction)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void UpdateNameShouldReturn400IfNameEndingIsNotCorrect() throws Exception {
+        mocks();
+
+        String body = "{ \"partnership_name\" : \"Test name\", \"name_ending\" : \"PP\" }";
+
+        mockMvc.perform(patch(PARTNERSHIP_PATCH_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .headers(httpHeaders)
+                        .requestAttr("transaction", transaction)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
     private void mocks(LimitedPartnershipDao limitedPartnershipDao) throws ServiceException {
         when(limitedPartnershipRepository.insert((LimitedPartnershipDao) any())).thenReturn(limitedPartnershipDao);
         when(limitedPartnershipRepository.save(any())).thenReturn(limitedPartnershipDao);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1143

### Change description
post-transition - name validation

### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.