### PR TITLE
LP-1822 Add FilingMode check for hasPsc statement validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/LimitedPartnershipValidator.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/LimitedPartnershipValidator.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static uk.gov.companieshouse.limitedpartnershipsapi.model.common.FilingMode.REGISTRATION;
+
 @Component
 public class LimitedPartnershipValidator {
     private static final String CLASS_NAME = DataDto.class.getName();
@@ -51,7 +53,7 @@ public class LimitedPartnershipValidator {
 
         checkCommonFields(dataDto, filingMode, errorsList);
         checkPartnershipTypeSpecificFields(dataDto, filingMode, errorsList);
-        validateHasPersonWithSignificantControl(dataDto, errorsList);
+        validateHasPersonWithSignificantControl(dataDto, filingMode, errorsList);
 
         return errorsList;
     }
@@ -86,7 +88,18 @@ public class LimitedPartnershipValidator {
         }
     }
 
-    protected void validateHasPersonWithSignificantControl(DataDto dataDto, List<ValidationStatusError> errorsList) {
+    protected void validateHasPersonWithSignificantControl(DataDto dataDto, FilingMode filingMode, List<ValidationStatusError> errorsList) {
+        var errorLocation = "data.hasPersonWithSignificantControl";
+
+        if (!REGISTRATION.equals(filingMode)) {
+            if (Objects.nonNull(dataDto.getHasPersonWithSignificantControl())) {
+                errorsList.add(validationStatus.createValidationStatusError(
+                        "You can only declare whether the partnership will or will not have a person with significant control during registration",
+                        errorLocation));
+            }
+            return;
+        }
+
         var partnershipType = dataDto.getPartnershipType();
 
         if ((PartnershipType.SLP.equals(partnershipType)
@@ -94,14 +107,14 @@ public class LimitedPartnershipValidator {
                 && Objects.isNull(dataDto.getHasPersonWithSignificantControl())) {
             errorsList.add(validationStatus.createValidationStatusError(
                     "You must declare whether the partnership will or will not have a person with significant control",
-                    "data.hasPersonWithSignificantControl"));
+                    errorLocation));
         }
         if ((PartnershipType.LP.equals(partnershipType)
                 || PartnershipType.PFLP.equals(partnershipType))
                 && Objects.nonNull(dataDto.getHasPersonWithSignificantControl())) {
             errorsList.add(validationStatus.createValidationStatusError(
                     "This type of partnership can not have a person with significant control",
-                    "data.hasPersonWithSignificantControl"));
+                    errorLocation));
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceValidateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/LimitedPartnershipServiceValidateTest.java
@@ -168,6 +168,52 @@ class LimitedPartnershipServiceValidateTest {
     }
 
     @ParameterizedTest
+    @EnumSource(value = FilingMode.class, names = {"UNKNOWN", "DEFAULT"}, mode = EnumSource.Mode.EXCLUDE)
+    void shouldOnlyValidateHasPscWhenFilingModeIsRegistration(FilingMode filingMode) throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
+        // given
+        LimitedPartnershipDao limitedPartnershipSubmissionDao = createDao(SLP);
+        transaction.setFilingMode(filingMode.getDescription());
+        limitedPartnershipSubmissionDao.getData().setHasPersonWithSignificantControl(null);
+
+        when(repository.findByTransactionId(transaction.getId())).thenReturn(List.of(limitedPartnershipSubmissionDao));
+
+        // when
+        List<ValidationStatusError> results = service.validateLimitedPartnership(transaction);
+
+        // then
+        if (FilingMode.REGISTRATION.equals(filingMode)) {
+            var errorMessage = "You must declare whether the partnership will or will not have a person with significant control";
+            checkForError(results, errorMessage, "data.hasPersonWithSignificantControl");
+            assertEquals(1, results.size());
+        } else {
+            assertEquals(0, results.size());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = FilingMode.class, names = {"UNKNOWN", "DEFAULT"}, mode = EnumSource.Mode.EXCLUDE)
+    void shouldReturnErrorWhenHasPscNotNullAndIsNotRegistration(FilingMode filingMode) throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
+        // given
+        LimitedPartnershipDao limitedPartnershipSubmissionDao = createDao(SLP);
+        transaction.setFilingMode(filingMode.getDescription());
+        limitedPartnershipSubmissionDao.getData().setHasPersonWithSignificantControl(true);
+
+        when(repository.findByTransactionId(transaction.getId())).thenReturn(List.of(limitedPartnershipSubmissionDao));
+
+        // when
+        List<ValidationStatusError> results = service.validateLimitedPartnership(transaction);
+
+        // then
+        if (!FilingMode.REGISTRATION.equals(filingMode)) {
+            var errorMessage = "You can only declare whether the partnership will or will not have a person with significant control during registration";
+            checkForError(results, errorMessage, "data.hasPersonWithSignificantControl");
+            assertEquals(1, results.size());
+        } else {
+            assertEquals(0, results.size());
+        }
+    }
+
+    @ParameterizedTest
     @EnumSource(value = PartnershipType.class, names = {"UNKNOWN"}, mode = EnumSource.Mode.EXCLUDE)
     void shouldReturnErrorsWhenPartnershipDataIsInvalidAndJavaBeanAndCustomChecksFail(PartnershipType type) throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
         // given
@@ -216,6 +262,7 @@ class LimitedPartnershipServiceValidateTest {
 
         limitedPartnershipSubmissionDao.getData().setNameEnding(null);
         limitedPartnershipSubmissionDao.getData().setPartnershipNumber("LP123456");
+        limitedPartnershipSubmissionDao.getData().setHasPersonWithSignificantControl(null);
 
         transaction.setFilingMode(FilingMode.TRANSITION.getDescription());
 
@@ -237,6 +284,7 @@ class LimitedPartnershipServiceValidateTest {
 
         limitedPartnershipSubmissionDao.getData().setNameEnding(null);
         limitedPartnershipSubmissionDao.getData().setPartnershipNumber("LX123456");
+        limitedPartnershipSubmissionDao.getData().setHasPersonWithSignificantControl(null);
 
         transaction.setFilingMode(FilingMode.TRANSITION.getDescription());
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1822


### Change description
Fix for validation check on the 'has pscs' statement
Will now check what type of filing mode (journey) is being used , and will now also return a new error message if the statement choice has been provided when it shouldn't have been i.e. when not on a Registration journey.


### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.