### PR TITLE
Feature/psc/lp 1817 list of psc endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/InterceptorConfig.java
@@ -29,7 +29,8 @@ public class InterceptorConfig implements WebMvcConfigurer {
             "/transactions/*/limited-partnership/general-partners",
             "/transactions/*/limited-partnership/limited-partner/**",
             "/transactions/*/limited-partnership/limited-partners",
-            "/transactions/*/limited-partnership/person-with-significant-control/**"
+            "/transactions/*/limited-partnership/person-with-significant-control/**",
+            "/transactions/*/limited-partnership/persons-with-significant-control"
     };
 
     private static final String[] COST_ENDPOINTS = {

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlController.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlController.java
@@ -62,7 +62,7 @@ public class PersonWithSignificantControlController {
 
     @GetMapping("/persons-with-significant-control")
     public ResponseEntity<List<PersonWithSignificantControlDto>> getPersonsWithSignificantControl(@RequestAttribute(TRANSACTION_KEY) Transaction transaction,
-                                                                                                  @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) {
+                                                                                                  @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException {
         String transactionId = transaction.getId();
         HashMap<String, Object> logMap = new HashMap<>();
         logMap.put(URL_PARAM_TRANSACTION_ID, transactionId);

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlController.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlController.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.limitedpartnershipsapi.utils.ApiLogger;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 
 import static uk.gov.companieshouse.api.util.security.EricConstants.ERIC_IDENTITY;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.ERIC_REQUEST_ID_KEY;
@@ -57,6 +58,17 @@ public class PersonWithSignificantControlController {
         ApiLogger.infoContext(requestId, String.format("Retrieving a person with significant control %s", personWithSignificantControlId), logMap);
         var dto = personWithSignificantControlService.getPersonWithSignificantControl(transaction, personWithSignificantControlId);
         return ResponseEntity.ok().body(dto);
+    }
+
+    @GetMapping("/persons-with-significant-control")
+    public ResponseEntity<List<PersonWithSignificantControlDto>> getPersonsWithSignificantControl(@RequestAttribute(TRANSACTION_KEY) Transaction transaction,
+                                                                                                  @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) {
+        String transactionId = transaction.getId();
+        HashMap<String, Object> logMap = new HashMap<>();
+        logMap.put(URL_PARAM_TRANSACTION_ID, transactionId);
+        ApiLogger.infoContext(requestId, "Retrieving list of persons with significant control", logMap);
+
+        return ResponseEntity.ok().body(personWithSignificantControlService.getPersonWithSignificantControlList(transaction));
     }
 
     @PostMapping("/person-with-significant-control")

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/GeneralPartnerMapper.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/GeneralPartnerMapper.java
@@ -4,14 +4,12 @@ import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
-import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Country;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Nationality;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.generalpartner.dao.GeneralPartnerDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.generalpartner.dto.GeneralPartnerDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.generalpartner.dto.GeneralPartnerDto;
 
-@Component
 @Mapper(uses = JsonNullableMapper.class,
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
         componentModel = "spring")

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnerMapper.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnerMapper.java
@@ -4,14 +4,12 @@ import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
-import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Country;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Nationality;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.limitedpartner.dao.LimitedPartnerDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.limitedpartner.dto.LimitedPartnerDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.limitedpartner.dto.LimitedPartnerDto;
 
-@Component
 @Mapper(uses = JsonNullableMapper.class,
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
         componentModel = "spring")

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipIncorporationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipIncorporationMapper.java
@@ -3,11 +3,9 @@ package uk.gov.companieshouse.limitedpartnershipsapi.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
-import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.incorporation.dao.LimitedPartnershipIncorporationDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.incorporation.dto.LimitedPartnershipIncorporationDto;
 
-@Component
 @Mapper(componentModel = "spring")
 public interface LimitedPartnershipIncorporationMapper {
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipMapper.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipMapper.java
@@ -2,13 +2,11 @@ package uk.gov.companieshouse.limitedpartnershipsapi.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
-import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.Jurisdiction;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.PartnershipNameEnding;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.dao.LimitedPartnershipDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.dto.LimitedPartnershipDto;
 
-@Component
 @Mapper(componentModel = "spring")
 public interface LimitedPartnershipMapper {
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/PersonWithSignificantControlMapper.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/PersonWithSignificantControlMapper.java
@@ -5,7 +5,6 @@ import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
-import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Country;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Nationality;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.NatureOfControl;
@@ -15,7 +14,6 @@ import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantc
 
 import java.util.List;
 
-@Component
 @Mapper(uses = JsonNullableMapper.class,
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
         componentModel = "spring")

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
@@ -50,6 +50,8 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
     @EnumValid(message = "Type must be valid")
     private PersonWithSignificantControlType type;
 
+    private boolean completed;
+
     // PERSON
 
     @JsonProperty("forename")
@@ -283,6 +285,14 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
 
     public void setType(PersonWithSignificantControlType type) {
         this.type = type;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
     }
 }
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
@@ -13,7 +13,9 @@ import uk.gov.companieshouse.limitedpartnershipsapi.repository.PersonWithSignifi
 import uk.gov.companieshouse.limitedpartnershipsapi.utils.ApiLogger;
 import uk.gov.companieshouse.limitedpartnershipsapi.utils.NationalityUtils;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static java.util.Objects.requireNonNullElse;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL;
@@ -47,6 +49,12 @@ public class PersonWithSignificantControlService {
         checkPersonWithSignificantControlIsLinkedToTransaction(transaction, personWithSignificantControlId, kind);
 
         return mapper.daoToDto(personWithSignificantControlDao);
+    }
+
+    public List<PersonWithSignificantControlDto> getPersonWithSignificantControlList(Transaction transaction) {
+        return repository.findAllByTransactionIdOrderByUpdatedAtDesc(transaction.getId()).stream()
+                .map(mapper::daoToDto)
+                .toList();
     }
 
     public String createPersonWithSignificantControl(Transaction transaction, PersonWithSignificantControlDto personWithSignificantControlDto, String requestId, String userId) throws ServiceException {

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
@@ -13,7 +13,6 @@ import uk.gov.companieshouse.limitedpartnershipsapi.repository.PersonWithSignifi
 import uk.gov.companieshouse.limitedpartnershipsapi.utils.ApiLogger;
 import uk.gov.companieshouse.limitedpartnershipsapi.utils.NationalityUtils;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
@@ -19,7 +19,6 @@ import uk.gov.companieshouse.limitedpartnershipsapi.utils.NationalityUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.List;
 
 import static java.util.Objects.requireNonNullElse;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL;
@@ -58,10 +57,19 @@ public class PersonWithSignificantControlService {
         return mapper.daoToDto(personWithSignificantControlDao);
     }
 
-    public List<PersonWithSignificantControlDto> getPersonWithSignificantControlList(Transaction transaction) {
-        return repository.findAllByTransactionIdOrderByUpdatedAtDesc(transaction.getId()).stream()
+    public List<PersonWithSignificantControlDto> getPersonWithSignificantControlList(Transaction transaction) throws ServiceException {
+        List<PersonWithSignificantControlDto> personWithSignificantControlDtos = repository.findAllByTransactionIdOrderByUpdatedAtDesc(transaction.getId()).stream()
                 .map(mapper::daoToDto)
                 .toList();
+
+        for (PersonWithSignificantControlDto personWithSignificantControlDto : personWithSignificantControlDtos) {
+            boolean isCompleted = personWithSignificantControlValidator.getValidatorByType(personWithSignificantControlDto.getData().getType())
+                    .validateFull(personWithSignificantControlDto, transaction)
+                    .isEmpty();
+            personWithSignificantControlDto.getData().setCompleted(isCompleted);
+        }
+
+        return personWithSignificantControlDtos;
     }
 
     public String createPersonWithSignificantControl(Transaction transaction, PersonWithSignificantControlDto personWithSignificantControlDto, String requestId, String userId) throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerTest.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantc
 import uk.gov.companieshouse.limitedpartnershipsapi.service.PersonWithSignificantControlService;
 import uk.gov.companieshouse.limitedpartnershipsapi.utils.ApiLogger;
 
+import java.util.List;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -168,5 +169,16 @@ class PersonWithSignificantControlControllerTest {
 
         assertEquals(HttpStatus.NO_CONTENT.value(), response.getStatusCode().value());
         verify(personWithSignificantControlService).deletePersonWithSignificantControl(transaction, PERSON_WITH_SIGNIFICANT_CONTROL_ID, REQUEST_ID);
+    }
+
+    @Test
+    void testGetPersonsWithSignificantControlReturnsList() {
+        List<PersonWithSignificantControlDto> personWithSignificantControlDtoList = List.of(new PersonWithSignificantControlDto(), new PersonWithSignificantControlDto());
+        when(personWithSignificantControlService.getPersonWithSignificantControlList(transaction)).thenReturn(personWithSignificantControlDtoList);
+
+        var response = personWithSignificantControlController.getPersonsWithSignificantControl(transaction, REQUEST_ID);
+
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
+        assertEquals(personWithSignificantControlDtoList, response.getBody());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerTest.java
@@ -161,7 +161,7 @@ class PersonWithSignificantControlControllerTest {
     }
 
     @Test
-    void testGetPersonsWithSignificantControlReturnsList() {
+    void testGetPersonsWithSignificantControlReturnsList() throws ServiceException {
         List<PersonWithSignificantControlDto> personWithSignificantControlDtoList = List.of(new PersonWithSignificantControlDto(), new PersonWithSignificantControlDto());
         when(personWithSignificantControlService.getPersonWithSignificantControlList(transaction)).thenReturn(personWithSignificantControlDtoList);
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceTest.java
@@ -290,20 +290,21 @@ class PersonWithSignificantControlServiceTest {
     }
 
     @Test
-    void testGetPersonWithSignificantControlList() {
-        PersonWithSignificantControlDao personWithSignificantControlDao1 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().personWithSignificantControlDao().build();
+    void testGetPersonWithSignificantControlList() throws ServiceException{
+        PersonWithSignificantControlDao personWithSignificantControlDao1 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().relevantLegalEntityPersonWithSignificantControlDao().build();
         personWithSignificantControlDao1.setTransactionId(TRANSACTION.getId());
-        PersonWithSignificantControlDao personWithSignificantControlDao2 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().personWithSignificantControlDao().build();
+        PersonWithSignificantControlDao personWithSignificantControlDao2 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().relevantLegalEntityPersonWithSignificantControlDao().build();
         personWithSignificantControlDao2.setTransactionId(TRANSACTION.getId());
         List<PersonWithSignificantControlDao> personWithSignificantControlDaoList = List.of(personWithSignificantControlDao1, personWithSignificantControlDao2);
 
         when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION.getId())).thenReturn(personWithSignificantControlDaoList);
 
-        PersonWithSignificantControlDto personWithSignificantControlDto1 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDtoBuilder().personWithSignificantControlDto().build();
-        PersonWithSignificantControlDto personWithSignificantControlDto2 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDtoBuilder().personWithSignificantControlDto().build();
+        PersonWithSignificantControlDto personWithSignificantControlDto1 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDtoBuilder().relevantLegalEntityPersonWithSignificantControlDto().build();
+        PersonWithSignificantControlDto personWithSignificantControlDto2 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDtoBuilder().relevantLegalEntityPersonWithSignificantControlDto().build();
 
         when(mapper.daoToDto(personWithSignificantControlDao1)).thenReturn(personWithSignificantControlDto1);
         when(mapper.daoToDto(personWithSignificantControlDao2)).thenReturn(personWithSignificantControlDto2);
+        when(personWithSignificantControlValidator.getValidatorByType(any(PersonWithSignificantControlType.class))).thenReturn(personWithSignificantControlValidatorStrategy);
 
         List<PersonWithSignificantControlDto> personWithSignificantControlDtoList = personWithSignificantControlService.getPersonWithSignificantControlList(TRANSACTION);
 
@@ -311,7 +312,7 @@ class PersonWithSignificantControlServiceTest {
     }
 
     @Test
-    void testGetPersonWithSignificantControlList_Empty() {
+    void testGetPersonWithSignificantControlList_Empty() throws ServiceException{
         when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION.getId())).thenReturn(new ArrayList<>());
 
         List<PersonWithSignificantControlDto> personWithSignificantControlDtoList = personWithSignificantControlService.getPersonWithSignificantControlList(TRANSACTION);

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceTest.java
@@ -18,8 +18,11 @@ import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantc
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.repository.PersonWithSignificantControlRepository;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -270,5 +273,35 @@ class PersonWithSignificantControlServiceTest {
                 ResourceNotFoundException.class,
                 () -> personWithSignificantControlService.deletePersonWithSignificantControl(TRANSACTION, PSC_ID, REQUEST_ID));
         assertEquals(String.format("Transaction id: %s does not have a resource that matches person with significant control id: %s", TRANSACTION.getId(), PSC_ID), resourceNotFoundException.getMessage());
+    }
+
+    @Test
+    void testGetPersonWithSignificantControlList() {
+        PersonWithSignificantControlDao personWithSignificantControlDao1 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().personWithSignificantControlDao().build();
+        personWithSignificantControlDao1.setTransactionId(TRANSACTION.getId());
+        PersonWithSignificantControlDao personWithSignificantControlDao2 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().personWithSignificantControlDao().build();
+        personWithSignificantControlDao2.setTransactionId(TRANSACTION.getId());
+        List<PersonWithSignificantControlDao> personWithSignificantControlDaoList = List.of(personWithSignificantControlDao1, personWithSignificantControlDao2);
+
+        when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION.getId())).thenReturn(personWithSignificantControlDaoList);
+
+        PersonWithSignificantControlDto personWithSignificantControlDto1 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDtoBuilder().personWithSignificantControlDto().build();
+        PersonWithSignificantControlDto personWithSignificantControlDto2 = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDtoBuilder().personWithSignificantControlDto().build();
+
+        when(mapper.daoToDto(personWithSignificantControlDao1)).thenReturn(personWithSignificantControlDto1);
+        when(mapper.daoToDto(personWithSignificantControlDao2)).thenReturn(personWithSignificantControlDto2);
+
+        List<PersonWithSignificantControlDto> personWithSignificantControlDtoList = personWithSignificantControlService.getPersonWithSignificantControlList(TRANSACTION);
+
+        assertThat(personWithSignificantControlDtoList).containsExactly(personWithSignificantControlDto1, personWithSignificantControlDto2);
+    }
+
+    @Test
+    void testGetPersonWithSignificantControlList_Empty() {
+        when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION.getId())).thenReturn(new ArrayList<>());
+
+        List<PersonWithSignificantControlDto> personWithSignificantControlDtoList = personWithSignificantControlService.getPersonWithSignificantControlList(TRANSACTION);
+
+        assertEquals(0, personWithSignificantControlDtoList.size());
     }
 }


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1817


### Change description
Add new controller endpoint for retrieving a list of persons with significant control
Add Service method for returning list of persons with significant control

Remove redundant Component annotation from Mapper interfaces -> Mapper impl's automatically get the component annotation when using Mapper annotation(componentModel = "spring". If we put it on the interface spring finds two candidates for the bean -> "More than one bean" error.

### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.