### PR TITLE
LP-1734 individual person PSC validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
@@ -55,12 +55,18 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
     // PERSON
 
     @JsonProperty("forename")
+    @Size(max = LONG_MAX_SIZE, message = "Forename " + MAX_SIZE_MESSAGE)
+    @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Forename " + INVALID_CHARACTERS_MESSAGE)
     private String forename;
 
     @JsonProperty("former_names")
+    @Size(max = LONG_MAX_SIZE, message = "Former names " + MAX_SIZE_MESSAGE)
+    @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Former names " + INVALID_CHARACTERS_MESSAGE)
     private String formerNames;
 
     @JsonProperty("surname")
+    @Size(max = LONG_MAX_SIZE, message = "Surname " + MAX_SIZE_MESSAGE)
+    @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Surname " + INVALID_CHARACTERS_MESSAGE)
     private String surname;
 
     @JsonProperty("date_of_birth")
@@ -68,12 +74,15 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
     private LocalDate dateOfBirth;
 
     @JsonProperty("nationality1")
+    @EnumValid(message = "Nationality 1 must be valid")
     private Nationality nationality1;
 
     @JsonProperty("nationality2")
+    @EnumValid(message = "Nationality 2 must be valid")
     private Nationality nationality2;
 
     @JsonProperty("usual_residential_address")
+    @Valid
     private AddressDto usualResidentialAddress;
 
     // RELEVANT LEGAL ENTITY (RLE) && OTHER REGISTRABLE PERSON (ORP)

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
@@ -111,8 +111,15 @@ public class PersonWithSignificantControlService {
     }
 
     private void handleLegalEntityRegistrationLocationOptionality(PersonWithSignificantControlDataDto personWithSignificantControlChangesDataDto, PersonWithSignificantControlDataDto data) {
-        if (personWithSignificantControlChangesDataDto.getLegalEntityRegistrationLocation() == null) {
-            data.setLegalEntityRegistrationLocation(null);
+        // Check RLE mandatory fields are present before setting legalEntityRegistrationLocation to null as this
+        // field is only needed when the person with significant control is a RLE.
+        // This is to avoid deleting the legalEntityRegistrationLocation when patching where
+        // legalEntityRegistrationLocation is not included in the patch.
+        if (personWithSignificantControlChangesDataDto.getLegalEntityName() != null
+            && personWithSignificantControlChangesDataDto.getLegalForm() != null
+            && personWithSignificantControlChangesDataDto.getGoverningLaw() != null
+            && personWithSignificantControlChangesDataDto.getLegalEntityRegistrationLocation() == null) {
+                data.setLegalEntityRegistrationLocation(null);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
@@ -1,24 +1,70 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.service.validator.personwithsignificantcontrol;
 
+import jakarta.validation.Validator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.ServiceException;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDto;
+import uk.gov.companieshouse.limitedpartnershipsapi.service.validator.ValidationStatus;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
 public class IndividualPersonValidatorStrategy extends PersonWithSignificantControlValidatorStrategy {
 
+    private final Validator validator;
+    private final ValidationStatus validationStatus;
 
-    @Override
-    public List<ValidationStatusError> validateFull(PersonWithSignificantControlDto personWithSignificantControlDto) throws ServiceException {
-        return List.of();
+    @Autowired
+    public IndividualPersonValidatorStrategy(Validator validator,
+                                                ValidationStatus validationStatus) {
+        this.validator = validator;
+        this.validationStatus = validationStatus;
     }
 
     @Override
     public void validatePartial(PersonWithSignificantControlDto personWithSignificantControlDto) throws NoSuchMethodException, MethodArgumentNotValidException, ServiceException {
-        // TODO
+        BindingResult bindingResult = new BeanPropertyBindingResult(personWithSignificantControlDto, DATA_DTO_CLASS_NAME);
+
+        performAnnotationValidation(personWithSignificantControlDto, validator, bindingResult);
+
+        // null checks for mandatory fields
+        var data = personWithSignificantControlDto.getData();
+        checkNotNullOrEmpty(data.getForename(), "data.forename", "Forename is required", bindingResult);
+        checkNotNullOrEmpty(data.getSurname(), "data.surname", "Surname is required", bindingResult);
+        if (data.getDateOfBirth() == null) {
+            addError("data.dateOfBirth", "Date of birth is required", bindingResult);
+        }
+        checkNotNullOrEmpty(data.getNationality1(), "data.nationality1", "Nationality 1 is required", bindingResult);
+
+        if (bindingResult.hasErrors()) {
+            var methodParameter = new MethodParameter(PersonWithSignificantControlDataDto.class.getConstructor(), -1);
+            throw new MethodArgumentNotValidException(methodParameter, bindingResult);
+        }
+    }
+
+    @Override
+    public List<ValidationStatusError> validateFull(PersonWithSignificantControlDto personWithSignificantControlDto) throws ServiceException {
+        List<ValidationStatusError> errorsList = new ArrayList<>();
+        getPartialValidationErrors(personWithSignificantControlDto, validationStatus, errorsList);
+
+        var dataDto = personWithSignificantControlDto.getData();
+
+        if (dataDto.getUsualResidentialAddress() == null) {
+            errorsList.add(validationStatus.createValidationStatusError("Usual residential address is required", "data.usualResidentialAddress"));
+        }
+
+        if (dataDto.getServiceAddress() == null) {
+            errorsList.add(validationStatus.createValidationStatusError("Service address is required", "data.serviceAddress"));
+        }
+
+        return errorsList;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
@@ -68,7 +68,17 @@ public abstract class PersonWithSignificantControlValidatorStrategy {
 
     protected List<ValidationStatusError> validateFullRleOrOrp(PersonWithSignificantControlDto personWithSignificantControlDto, ValidationStatus validationStatus) throws ServiceException {
         List<ValidationStatusError> errorsList = new ArrayList<>();
+        getPartialValidationErrors(personWithSignificantControlDto, validationStatus, errorsList);
 
+        var dataDto = personWithSignificantControlDto.getData();
+        if (dataDto.getPrincipalOfficeAddress() == null) {
+            errorsList.add(validationStatus.createValidationStatusError("Principal office address is required", "data.principalOfficeAddress"));
+        }
+
+        return errorsList;
+    }
+
+    protected void getPartialValidationErrors(PersonWithSignificantControlDto personWithSignificantControlDto, ValidationStatus validationStatus, List<ValidationStatusError> errorsList) throws ServiceException {
         try {
             validatePartial(personWithSignificantControlDto);
         } catch (MethodArgumentNotValidException e) {
@@ -76,13 +86,5 @@ public abstract class PersonWithSignificantControlValidatorStrategy {
         } catch (NoSuchMethodException e) {
             throw new ServiceException(e.getMessage());
         }
-
-        var dataDto = personWithSignificantControlDto.getData();
-
-        if (dataDto.getPrincipalOfficeAddress() == null) {
-            errorsList.add(validationStatus.createValidationStatusError("Principal office address is required", "data.principalOfficeAddress"));
-        }
-
-        return errorsList;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
@@ -112,6 +112,23 @@ public class PersonWithSignificantControlBuilder {
             return this;
         }
 
+        public PersonWithSignificantControlDaoBuilder otherRegistrablePersonWithSignificantControlDao() {
+            personWithSignificantControlDataDao.setAppointmentId(APPOINTMENT_ID);
+            personWithSignificantControlDataDao.setKind(FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL);
+            personWithSignificantControlDataDao.setCountry(ENGLAND.getDescription());
+            personWithSignificantControlDataDao.setEtag(ETAG);
+            personWithSignificantControlDataDao.setGoverningLaw(GOVERNING_LAW);
+            personWithSignificantControlDataDao.setLegalEntityName(LEGAL_ENTITY_NAME);
+            personWithSignificantControlDataDao.setLegalForm(LEGAL_FORM);
+            personWithSignificantControlDataDao.setNaturesOfControl(NATURES_OF_CONTROL_LIST_DESCRIPTIONS);
+            personWithSignificantControlDataDao.setPrincipalOfficeAddress(createAddressDao(POA_PREFIX));
+            personWithSignificantControlDataDao.setType(PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY);
+
+            personWithSignificantControlDao.setId(ID);
+            personWithSignificantControlDao.setData(personWithSignificantControlDataDao);
+            return this;
+        }
+
         public PersonWithSignificantControlDaoBuilder withKind(String kind) {
             this.personWithSignificantControlDataDao.setKind(kind);
             return this;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -356,11 +356,14 @@ class PersonWithSignificantControlControllerValidationTest {
         private static final String JSON_DATE_OF_BIRTH_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": null, \"nationality1\": \"English\" }";
         private static final String JSON_NATIONALITY1_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": null }";
         private static final String JSON_FORENAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"§§§\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_FORMER_NAMES_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"former_names\": \"§§§\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_SURNAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"§§§\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_NATIONALITY1_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"§§§\" }";
         private static final String JSON_NATIONALITY2_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\", \"nationality2\": \"§§§\" }";
         private static final String JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"" + TOO_MANY_CHARS + "\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"former_names\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+
 
         @ParameterizedTest
         @ValueSource(strings = {JSON_CORRECT_IP, JSON_CORRECT_MANDATORY_ONLY_IP})
@@ -383,10 +386,12 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ Nationality 1 is required",
                 JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
+                JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
-                JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160"
+                JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",
+                JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.formerNames $ Former names must be less than 160"
         }, delimiter = '$')
         void shouldReturn400_create_IP(String body, String field, String errorMessage) throws Exception {
             mocks();
@@ -408,10 +413,12 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ Nationality 1 is required",
                 JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
+                JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
-                JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160"
+                JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",
+                JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.formerNames $ Former names must be less than 160"
         }, delimiter = '$')
         void shouldReturn400_update_IP(String body, String field, String errorMessage) throws Exception {
             mocks();

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -367,7 +367,7 @@ class PersonWithSignificantControlControllerValidationTest {
 
         @ParameterizedTest
         @ValueSource(strings = {JSON_CORRECT_IP, JSON_CORRECT_MANDATORY_ONLY_IP})
-        void shouldReturn201_RLE(String jsonPayload) throws Exception {
+        void shouldReturn201_IP(String jsonPayload) throws Exception {
             mocks();
             mockMvc.perform(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -258,7 +258,7 @@ class PersonWithSignificantControlControllerValidationTest {
         private static final String JSON_GOVERNING_LAW_IS_ABOVE_MAX_CHARS_ORP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"OTHER_REGISTRABLE_PERSON\", \"legal_entity_name\": \"aaaa\", \"legal_form\": \"aaa\", \"governing_law\": \"" + TOO_MANY_CHARS + "\" }";
 
         @Test
-        void shouldReturn201_RLE() throws Exception {
+        void shouldReturn201_ORP() throws Exception {
             mocks();
             mockMvc.perform(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)
@@ -284,7 +284,7 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_LEGAL_FORM_IS_ABOVE_MAX_CHARS_ORP + "$ data.legalForm $ Legal form " + "must be less than 160",
                 JSON_GOVERNING_LAW_IS_ABOVE_MAX_CHARS_ORP + "$ data.governingLaw $ Governing law " + "must be less than 160"
         }, delimiter = '$')
-        void shouldReturn400_create_RLE(String body, String field, String errorMessage) throws Exception {
+        void shouldReturn400_create_ORP(String body, String field, String errorMessage) throws Exception {
             mocks();
             mockMvc.perform(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)
@@ -311,7 +311,109 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_LEGAL_FORM_IS_ABOVE_MAX_CHARS_ORP + "$ data.legalForm $ Legal form " + "must be less than 160",
                 JSON_GOVERNING_LAW_IS_ABOVE_MAX_CHARS_ORP + "$ data.governingLaw $ Governing law " + "must be less than 160"
         }, delimiter = '$')
-        void shouldReturn400_update_RLE(String body, String field, String errorMessage) throws Exception {
+        void shouldReturn400_update_ORP(String body, String field, String errorMessage) throws Exception {
+            mocks();
+            mockMvc.perform(patch(BASE_URL + "/" + PERSON_WITH_SIGNIFICANT_CONTROL_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .headers(httpHeaders)
+                            .requestAttr("transaction", transaction)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.['errors'].['" + field + "']").value(errorMessage));
+        }
+    }
+
+    @Nested
+    class IndividualPerson {
+        private static final String JSON_CORRECT_IP = """
+            {
+                "data": {
+                    "kind": "limited-partnership#person-with-significant-control",
+                    "type": "INDIVIDUAL_PERSON",
+                    "forename": "asasd",
+                    "surname": "dsfs",
+                    "date_of_birth": "1956-05-05",
+                    "nationality1": "English",
+                    "nationality2": "French"
+                }
+            }""";
+
+        private static final String JSON_CORRECT_MANDATORY_ONLY_IP = """
+            {
+                "data": {
+                    "kind": "limited-partnership#person-with-significant-control",
+                    "type": "INDIVIDUAL_PERSON",
+                    "forename": "asasd",
+                    "surname": "dsfs",
+                    "date_of_birth": "1956-05-05",
+                    "nationality1": "English"
+                }
+            }""";
+
+        private static final String JSON_FORENAME_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_SURNAME_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_DATE_OF_BIRTH_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": null, \"nationality1\": \"English\" }";
+        private static final String JSON_NATIONALITY1_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": null }";
+        private static final String JSON_FORENAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"§§§\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_SURNAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"§§§\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_NATIONALITY1_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"§§§\" }";
+        private static final String JSON_NATIONALITY2_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\", \"nationality2\": \"§§§\" }";
+        private static final String JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"" + TOO_MANY_CHARS + "\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+
+        @ParameterizedTest
+        @ValueSource(strings = {JSON_CORRECT_IP, JSON_CORRECT_MANDATORY_ONLY_IP})
+        void shouldReturn201_RLE(String jsonPayload) throws Exception {
+            mocks();
+            mockMvc.perform(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .headers(httpHeaders)
+                            .requestAttr("transaction", transaction)
+                            .content(jsonPayload))
+                    .andExpect(status().isCreated());
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                JSON_FORENAME_IS_REQUIRED_IP + "$ data.forename $ Forename is required",
+                JSON_SURNAME_IS_REQUIRED_IP + "$ data.surname $ Surname is required",
+                JSON_DATE_OF_BIRTH_IS_REQUIRED_IP + "$ data.dateOfBirth $ Date of birth is required",
+                JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ Nationality 1 is required",
+                JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
+                JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
+                JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
+                JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
+                JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
+                JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160"
+        }, delimiter = '$')
+        void shouldReturn400_create_IP(String body, String field, String errorMessage) throws Exception {
+            mocks();
+            mockMvc.perform(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .headers(httpHeaders)
+                            .requestAttr("transaction", transaction)
+                            .content(String.format("{\"data\":%s}", body)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.['errors'].['" + field + "']").value(errorMessage));
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                JSON_FORENAME_IS_REQUIRED_IP + "$ data.forename $ Forename is required",
+                JSON_SURNAME_IS_REQUIRED_IP + "$ data.surname $ Surname is required",
+                JSON_DATE_OF_BIRTH_IS_REQUIRED_IP + "$ data.dateOfBirth $ Date of birth is required",
+                JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ Nationality 1 is required",
+                JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
+                JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
+                JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
+                JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
+                JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
+                JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160"
+        }, delimiter = '$')
+        void shouldReturn400_update_IP(String body, String field, String errorMessage) throws Exception {
             mocks();
             mockMvc.perform(patch(BASE_URL + "/" + PERSON_WITH_SIGNIFICANT_CONTROL_ID)
                             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
@@ -20,10 +20,12 @@ import uk.gov.companieshouse.limitedpartnershipsapi.model.common.FilingMode;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Nationality;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.dao.AddressDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.dto.AddressDto;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.NatureOfControl;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dao.PersonWithSignificantControlDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.repository.PersonWithSignificantControlRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -202,6 +204,49 @@ class PersonWithSignificantControlServiceUpdateTest {
 
         assertThat(savedPersonWithSignificantControlDao.getData().getNationality1()).isEqualTo(Nationality.AMERICAN.getDescription());
         assertThat(savedPersonWithSignificantControlDao.getData().getNationality2()).isNull();
+    }
+
+    @Test
+    void shouldHandleLegalEntityRegistrationLocationOptionality_shouldNotDelete() throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
+        PersonWithSignificantControlDao personWithSignificantControlDao = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().relevantLegalEntityPersonWithSignificantControlDao().build();
+
+        var preChangeLegalEntityRegistrationLocation = personWithSignificantControlDao.getData().getLegalEntityRegistrationLocation();
+        assertThat(preChangeLegalEntityRegistrationLocation).isNotEmpty();
+
+        PersonWithSignificantControlDataDto changesDto = new PersonWithSignificantControlDataDto();
+        changesDto.setNaturesOfControl(List.of(NatureOfControl.INDIVIDUAL_TRUST_CONTROL));
+
+        when(personWithSignificantControlRepository.findById(personWithSignificantControlDao.getId())).thenReturn(Optional.of(personWithSignificantControlDao));
+        when(transactionService.isTransactionLinkedToResource(any(), any(), any())).thenReturn(true);
+
+        personWithSignificantControlService.updatePersonWithSignificantControl(transaction, PSC_ID, changesDto, REQUEST_ID, USER_ID);
+
+        verify(personWithSignificantControlRepository).save(pscDaoArgumentCaptor.capture());
+        PersonWithSignificantControlDao savedPersonWithSignificantControlDao = pscDaoArgumentCaptor.getValue();
+        assertThat(savedPersonWithSignificantControlDao.getData().getLegalEntityRegistrationLocation()).isEqualTo(preChangeLegalEntityRegistrationLocation);
+    }
+
+    @Test
+    void shouldHandleLegalEntityRegistrationLocationOptionality_shouldDelete() throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
+        PersonWithSignificantControlDao personWithSignificantControlDao = new PersonWithSignificantControlBuilder.PersonWithSignificantControlDaoBuilder().relevantLegalEntityPersonWithSignificantControlDao().build();
+
+        var preChangeLegalEntityRegistrationLocation = personWithSignificantControlDao.getData().getLegalEntityRegistrationLocation();
+        assertThat(preChangeLegalEntityRegistrationLocation).isNotEmpty();
+
+        PersonWithSignificantControlDataDto changesDto = new PersonWithSignificantControlDataDto();
+        changesDto.setLegalEntityName("Test Legal Entity");
+        changesDto.setLegalForm("Test Legal Form");
+        changesDto.setGoverningLaw("Test Governing Law");
+        changesDto.setLegalEntityRegistrationLocation(null);
+
+        when(personWithSignificantControlRepository.findById(personWithSignificantControlDao.getId())).thenReturn(Optional.of(personWithSignificantControlDao));
+        when(transactionService.isTransactionLinkedToResource(any(), any(), any())).thenReturn(true);
+
+        personWithSignificantControlService.updatePersonWithSignificantControl(transaction, PSC_ID, changesDto, REQUEST_ID, USER_ID);
+
+        verify(personWithSignificantControlRepository).save(pscDaoArgumentCaptor.capture());
+        PersonWithSignificantControlDao savedPersonWithSignificantControlDao = pscDaoArgumentCaptor.getValue();
+        assertThat(savedPersonWithSignificantControlDao.getData().getLegalEntityRegistrationLocation()).isNull();
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceValidateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceValidateTest.java
@@ -159,7 +159,7 @@ class PersonWithSignificantControlServiceValidateTest {
             otherRegistrablePersonPersonWithSignificantControl =
                     new PersonWithSignificantControlBuilder
                             .PersonWithSignificantControlDaoBuilder()
-                            .relevantLegalEntityPersonWithSignificantControlDao()
+                            .otherRegistrablePersonWithSignificantControlDao()
                             .withTransactionId(TRANSACTION_ID)
                             .build();
         }
@@ -212,6 +212,91 @@ class PersonWithSignificantControlServiceValidateTest {
                     .singleElement()
                     .usingRecursiveComparison()
                     .isEqualTo(new ValidationStatusError("Name " + INVALID_CHARACTERS_MESSAGE, "data.legalEntityName", null, null));
+        }
+    }
+
+    @Nested
+    class IndividualPerson {
+
+        private PersonWithSignificantControlDao individualPersonPersonWithSignificantControl;
+
+        @BeforeEach
+        void setUp() {
+            individualPersonPersonWithSignificantControl =
+                    new PersonWithSignificantControlBuilder
+                            .PersonWithSignificantControlDaoBuilder()
+                            .individualPersonPersonWithSignificantControlDao()
+                            .withTransactionId(TRANSACTION_ID)
+                            .build();
+        }
+
+        @Test
+        void shouldReturnNoErrorsWhenPSCDataIsValid() throws ServiceException {
+            // given
+            when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID)).thenReturn(List.of(individualPersonPersonWithSignificantControl));
+
+            // when
+            List<ValidationStatusError> results = service.validatePersonsWithSignificantControl(transaction);
+
+            // then
+            verify(repository).findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID);
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        void shouldReturnErrorIfPOANotSupplied() throws ServiceException {
+            // given
+            individualPersonPersonWithSignificantControl.getData().setUsualResidentialAddress(null);
+
+            when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID)).thenReturn(List.of(individualPersonPersonWithSignificantControl));
+
+            // when
+            List<ValidationStatusError> results = service.validatePersonsWithSignificantControl(transaction);
+
+            // then
+            verify(repository).findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID);
+
+            assertThat(results)
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(new ValidationStatusError("Usual residential address is required", "data.usualResidentialAddress", null, null));
+        }
+
+        @Test
+        void shouldReturnErrorIfServiceAddressNotSupplied() throws ServiceException {
+            // given
+            individualPersonPersonWithSignificantControl.getData().setServiceAddress(null);
+
+            when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID)).thenReturn(List.of(individualPersonPersonWithSignificantControl));
+
+            // when
+            List<ValidationStatusError> results = service.validatePersonsWithSignificantControl(transaction);
+
+            // then
+            verify(repository).findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID);
+
+            assertThat(results)
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(new ValidationStatusError("Service address is required", "data.serviceAddress", null, null));
+        }
+
+        @Test
+        void shouldReturnErrorsIfDataIsInvalid() throws ServiceException {
+            // given
+            individualPersonPersonWithSignificantControl.getData().setForename("§§§§§§§");
+
+            when(repository.findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID)).thenReturn(List.of(individualPersonPersonWithSignificantControl));
+
+            // when
+            List<ValidationStatusError> results = service.validatePersonsWithSignificantControl(transaction);
+
+            // then
+            verify(repository).findAllByTransactionIdOrderByUpdatedAtDesc(TRANSACTION_ID);
+            assertThat(results)
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(new ValidationStatusError("Forename " + INVALID_CHARACTERS_MESSAGE, "data.forename", null, null));
         }
     }
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1734


### Change description
Add partial and full validation for Individual Person PSCs
Created new method getPartialValidationErrors in the parent PersonWithSignificantControlValidatorStrategy class to reduce duplication.
Updated tests.


### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.