### PR TITLE
LP-1920 Add extra fields for individual person PSC

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dao/PersonWithSignificantControlDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dao/PersonWithSignificantControlDataDao.java
@@ -38,8 +38,17 @@ public class PersonWithSignificantControlDataDao {
 
     // PERSON
 
+    @Field("consent_checked")
+    private Boolean consentChecked;
+
+    @Field("title")
+    private String title;
+
     @Field("forename")
     private String forename;
+
+    @Field("middle_names")
+    private String middleNames;
 
     @Field("former_names")
     private String formerNames;
@@ -264,5 +273,29 @@ public class PersonWithSignificantControlDataDao {
 
     public void setType(PersonWithSignificantControlType type) {
         this.type = type;
+    }
+
+    public Boolean getConsentChecked() {
+        return consentChecked;
+    }
+
+    public void setConsentChecked(Boolean consentChecked) {
+        this.consentChecked = consentChecked;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getMiddleNames() {
+        return middleNames;
+    }
+
+    public void setMiddleNames(String middleNames) {
+        this.middleNames = middleNames;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
@@ -58,17 +58,17 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
     private Boolean consentChecked;
 
     @JsonProperty("title")
-    @Size(max = LONG_MAX_SIZE, message = "Title " + MAX_SIZE_MESSAGE)
+    @Size(max = 50, message = "Title " + MAX_SIZE_MESSAGE)
     @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Title " + INVALID_CHARACTERS_MESSAGE)
     private String title;
 
     @JsonProperty("forename")
-    @Size(max = LONG_MAX_SIZE, message = "Forename " + MAX_SIZE_MESSAGE)
+    @Size(max = 50, message = "Forename " + MAX_SIZE_MESSAGE)
     @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Forename " + INVALID_CHARACTERS_MESSAGE)
     private String forename;
 
     @JsonProperty("middle_names")
-    @Size(max = LONG_MAX_SIZE, message = "Middle names " + MAX_SIZE_MESSAGE)
+    @Size(max = 50, message = "Middle names " + MAX_SIZE_MESSAGE)
     @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Middle names " + INVALID_CHARACTERS_MESSAGE)
     private String middleNames;
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
@@ -320,13 +320,7 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
         this.completed = completed;
     }
 
-    public Boolean getConsentChecked() {
-        return consentChecked;
-    }
 
-    public void setConsentChecked(Boolean consentChecked) {
-        this.consentChecked = consentChecked;
-    }
 
     public String getTitle() {
         return title;
@@ -334,6 +328,14 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public Boolean getConsentChecked() {
+        return consentChecked;
+    }
+
+    public void setConsentChecked(Boolean consentChecked) {
+        this.consentChecked = consentChecked;
     }
 
     public String getMiddleNames() {

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
@@ -54,10 +54,23 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
 
     // PERSON
 
+    @JsonProperty("consent_checked")
+    private Boolean consentChecked;
+
+    @JsonProperty("title")
+    @Size(max = LONG_MAX_SIZE, message = "Title " + MAX_SIZE_MESSAGE)
+    @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Title " + INVALID_CHARACTERS_MESSAGE)
+    private String title;
+
     @JsonProperty("forename")
     @Size(max = LONG_MAX_SIZE, message = "Forename " + MAX_SIZE_MESSAGE)
     @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Forename " + INVALID_CHARACTERS_MESSAGE)
     private String forename;
+
+    @JsonProperty("middle_names")
+    @Size(max = LONG_MAX_SIZE, message = "Middle names " + MAX_SIZE_MESSAGE)
+    @Pattern(regexp = REG_EXP_FOR_ALLOWED_CHARACTERS, message = "Middle names " + INVALID_CHARACTERS_MESSAGE)
+    private String middleNames;
 
     @JsonProperty("former_names")
     @Size(max = LONG_MAX_SIZE, message = "Former names " + MAX_SIZE_MESSAGE)
@@ -305,6 +318,30 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
 
     public void setCompleted(boolean completed) {
         this.completed = completed;
+    }
+
+    public Boolean getConsentChecked() {
+        return consentChecked;
+    }
+
+    public void setConsentChecked(Boolean consentChecked) {
+        this.consentChecked = consentChecked;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getMiddleNames() {
+        return middleNames;
+    }
+
+    public void setMiddleNames(String middleNames) {
+        this.middleNames = middleNames;
     }
 }
 

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
@@ -107,6 +107,7 @@ public class PersonWithSignificantControlService {
 
         NationalityUtils.handleSecondNationalityOptionality(personWithSignificantControlChangesDataDto, dto.getData());
         handleLegalEntityRegistrationLocationOptionality(personWithSignificantControlChangesDataDto, dto.getData());
+        handlePersonOptionalFields(personWithSignificantControlChangesDataDto, dto.getData());
 
         var daoAfterPatch = mapper.dtoToDao(dto);
         // Need to ensure we don't lose the meta-data already set on the Mongo document (but lost when DAO is mapped to a DTO)
@@ -129,6 +130,18 @@ public class PersonWithSignificantControlService {
                 data.setLegalEntityRegistrationLocation(null);
         }
     }
+
+    private void handlePersonOptionalFields(PersonWithSignificantControlDataDto changesDto, PersonWithSignificantControlDataDto data) {
+        if (changesDto.getForename() != null && changesDto.getSurname() != null) {
+            if (changesDto.getMiddleNames() == null) {
+                data.setMiddleNames(null);
+            }
+            if (changesDto.getTitle() == null) {
+                data.setTitle(null);
+            }
+        }
+    }
+
 
     public void deletePersonWithSignificantControl(Transaction transaction, String personWithSignificantControlId, String requestId) throws ServiceException {
         PersonWithSignificantControlDao personWithSignificantControlDao = repository.findById(personWithSignificantControlId)

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
@@ -37,6 +37,9 @@ public class IndividualPersonValidatorStrategy extends PersonWithSignificantCont
 
         // null checks for mandatory fields
         var data = personWithSignificantControlDto.getData();
+        if (data.getConsentChecked() == null || Boolean.FALSE.equals(data.getConsentChecked())) {
+            addError("data.consentChecked", "Consent must be checked", bindingResult);
+        }
         checkNotNullOrEmpty(data.getForename(), "data.forename", "Forename is required", bindingResult);
         checkNotNullOrEmpty(data.getSurname(), "data.surname", "Surname is required", bindingResult);
         if (data.getDateOfBirth() == null) {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
@@ -25,9 +25,6 @@ public class PersonWithSignificantControlBuilder {
     public static final String PERSON_WITH_SIGNIFICANT_CONTROL_ID = "1234";
     public static final String ETAG = "eTag";
     public static final String APPOINTMENT_ID = "1234";
-    public static final String SURNAME = "Smith";
-    public static final String MIDDLE_NAMES = "John Jack";
-    public static final String TITLE = "Mr";
     public static final String GOVERNING_LAW = "law of england";
     public static final String LEGAL_ENTITY_REGISTER_NAME = "Legal Entity Register Name";
     public static final String LEGAL_FORM = "Legal Form";
@@ -62,7 +59,10 @@ public class PersonWithSignificantControlBuilder {
     private Country legalEntityRegistrationLocation = Country.ENGLAND;
 
     private Country country = ENGLAND;
+    private String title = "Mr";
     private String forename = "John";
+    private String middleNames = "John Jack";
+    private String surname = "Smith";
     private String formerNames = "Johnny";
     private Nationality nationality1 = BRITISH;
     private Nationality nationality2 = FRENCH;
@@ -89,6 +89,21 @@ public class PersonWithSignificantControlBuilder {
 
     public PersonWithSignificantControlBuilder withForename(String forename) {
         this.forename = forename;
+        return this;
+    }
+
+    public PersonWithSignificantControlBuilder withSurname(String surname) {
+        this.surname = surname;
+        return this;
+    }
+
+    public PersonWithSignificantControlBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public PersonWithSignificantControlBuilder withMiddleNames(String middleNames) {
+        this.middleNames = middleNames;
         return this;
     }
 
@@ -119,10 +134,10 @@ public class PersonWithSignificantControlBuilder {
         dataDto.setDateEffectiveFrom(DATE_EFFECTIVE_FROM);
         dataDto.setConsentChecked(true);
         dataDto.setDateOfBirth(DATE_OF_BIRTH);
-        dataDto.setTitle(TITLE);
-        dataDto.setMiddleNames(MIDDLE_NAMES);
+        dataDto.setTitle(title);
+        dataDto.setMiddleNames(middleNames);
         dataDto.setForename(forename);
-        dataDto.setSurname(SURNAME);
+        dataDto.setSurname(surname);
         dataDto.setFormerNames(formerNames);
         dataDto.setNationality1(nationality1);
         dataDto.setNationality2(nationality2);
@@ -206,10 +221,10 @@ public class PersonWithSignificantControlBuilder {
         dataDao.setDateOfBirth(DATE_OF_BIRTH);
         dataDao.setEtag(ETAG);
         dataDao.setConsentChecked(true);
-        dataDao.setTitle(TITLE);
+        dataDao.setTitle(title);
         dataDao.setForename(forename);
-        dataDao.setMiddleNames(MIDDLE_NAMES);
-        dataDao.setSurname(SURNAME);
+        dataDao.setMiddleNames(middleNames);
+        dataDao.setSurname(surname);
         dataDao.setFormerNames(formerNames);
         dataDao.setNationality1(nationality1.getDescription());
         dataDao.setNationality2(nationality2.getDescription());

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
@@ -26,6 +26,8 @@ public class PersonWithSignificantControlBuilder {
     public static final String ETAG = "eTag";
     public static final String APPOINTMENT_ID = "1234";
     public static final String SURNAME = "Smith";
+    public static final String MIDDLE_NAMES = "John Jack";
+    public static final String TITLE = "Mr";
     public static final String GOVERNING_LAW = "law of england";
     public static final String LEGAL_ENTITY_REGISTER_NAME = "Legal Entity Register Name";
     public static final String LEGAL_FORM = "Legal Form";
@@ -115,7 +117,10 @@ public class PersonWithSignificantControlBuilder {
         dataDto.setCountry(country);
         dataDto.setKind(kind);
         dataDto.setDateEffectiveFrom(DATE_EFFECTIVE_FROM);
+        dataDto.setConsentChecked(true);
         dataDto.setDateOfBirth(DATE_OF_BIRTH);
+        dataDto.setTitle(TITLE);
+        dataDto.setMiddleNames(MIDDLE_NAMES);
         dataDto.setForename(forename);
         dataDto.setSurname(SURNAME);
         dataDto.setFormerNames(formerNames);
@@ -200,7 +205,10 @@ public class PersonWithSignificantControlBuilder {
         dataDao.setDateEffectiveFrom(DATE_EFFECTIVE_FROM);
         dataDao.setDateOfBirth(DATE_OF_BIRTH);
         dataDao.setEtag(ETAG);
+        dataDao.setConsentChecked(true);
+        dataDao.setTitle(TITLE);
         dataDao.setForename(forename);
+        dataDao.setMiddleNames(MIDDLE_NAMES);
         dataDao.setSurname(SURNAME);
         dataDao.setFormerNames(formerNames);
         dataDao.setNationality1(nationality1.getDescription());

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/builder/PersonWithSignificantControlBuilder.java
@@ -25,6 +25,7 @@ public class PersonWithSignificantControlBuilder {
     public static final String PERSON_WITH_SIGNIFICANT_CONTROL_ID = "1234";
     public static final String ETAG = "eTag";
     public static final String APPOINTMENT_ID = "1234";
+    public static final String TITLE_MR = "Mr";
     public static final String GOVERNING_LAW = "law of england";
     public static final String LEGAL_ENTITY_REGISTER_NAME = "Legal Entity Register Name";
     public static final String LEGAL_FORM = "Legal Form";
@@ -52,6 +53,7 @@ public class PersonWithSignificantControlBuilder {
             NatureOfControl.INDIVIDUAL_FIRM_CONTROL,
             NatureOfControl.ORP_TRUST_CONTROL
     );
+    public static final String MIDDLE_NAMES = "John Jack";
 
     private String kind = FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL;
 
@@ -59,9 +61,9 @@ public class PersonWithSignificantControlBuilder {
     private Country legalEntityRegistrationLocation = Country.ENGLAND;
 
     private Country country = ENGLAND;
-    private String title = "Mr";
+    private String title = TITLE_MR;
     private String forename = "John";
-    private String middleNames = "John Jack";
+    private String middleNames = MIDDLE_NAMES;
     private String surname = "Smith";
     private String formerNames = "Johnny";
     private Nationality nationality1 = BRITISH;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerUpdateTest.java
@@ -43,7 +43,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_GENERAL_PARTNER;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
@@ -49,7 +49,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_LIMITED_PARTNER;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -349,14 +349,14 @@ class PersonWithSignificantControlControllerValidationTest {
         private static final String JSON_SURNAME_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_DATE_OF_BIRTH_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": null, \"nationality1\": \"English\" }";
         private static final String JSON_NATIONALITY1_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": null }";
-        private static final String JSON_TITlE_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"§§§§\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_TITLE_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"§§§§\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_FORENAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"§§§\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_FORMER_NAMES_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"former_names\": \"§§§\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_MIDDLE_NAMES_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Fred\", \"middle_names\": \"§§§\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_SURNAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"§§§\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_NATIONALITY1_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"§§§\" }";
         private static final String JSON_NATIONALITY2_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\", \"nationality2\": \"§§§\" }";
-        private static final String JSON_TITlE_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"" + TOO_MANY_CHARS + "\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_TITLE_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"" + TOO_MANY_CHARS + "\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Fred\", \"middle_names\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"" + TOO_MANY_CHARS + "\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
@@ -384,14 +384,14 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_SURNAME_IS_REQUIRED_IP + "$ data.surname $ Surname is required",
                 JSON_DATE_OF_BIRTH_IS_REQUIRED_IP + "$ data.dateOfBirth $ Date of birth is required",
                 JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ Nationality 1 is required",
-                JSON_TITlE_INVALID_CHARS_IP + "$ data.title $ Title " + INVALID_CHARACTERS_MESSAGE,
+                JSON_TITLE_INVALID_CHARS_IP + "$ data.title $ Title " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
                 JSON_MIDDLE_NAMES_INVALID_CHARS_IP + "$ data.middleNames $ Middle names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
-                JSON_TITlE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
+                JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
                 JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 160",
                 JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",
@@ -414,14 +414,14 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_CONSENT_IS_REQUIRED_FALSE_IP + "$ data.consentChecked $ Consent must be checked",
                 JSON_FORENAME_IS_REQUIRED_IP + "$ data.forename $ Forename is required",
                 JSON_SURNAME_IS_REQUIRED_IP + "$ data.surname $ Surname is required",
-                JSON_TITlE_INVALID_CHARS_IP + "$ data.title $ Title " + INVALID_CHARACTERS_MESSAGE,
+                JSON_TITLE_INVALID_CHARS_IP + "$ data.title $ Title " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
                 JSON_MIDDLE_NAMES_INVALID_CHARS_IP + "$ data.middleNames $ Middle names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
-                JSON_TITlE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
+                JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
                 JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 160",
                 JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -77,9 +76,6 @@ class PersonWithSignificantControlControllerValidationTest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockitoBean
     private PersonWithSignificantControlRepository repository;
@@ -325,6 +321,7 @@ class PersonWithSignificantControlControllerValidationTest {
                 "data": {
                     "kind": "limited-partnership#person-with-significant-control",
                     "type": "INDIVIDUAL_PERSON",
+                    "consent_checked" : "true",
                     "forename": "asasd",
                     "surname": "dsfs",
                     "date_of_birth": "1956-05-05",
@@ -338,6 +335,7 @@ class PersonWithSignificantControlControllerValidationTest {
                 "data": {
                     "kind": "limited-partnership#person-with-significant-control",
                     "type": "INDIVIDUAL_PERSON",
+                    "consent_checked" : "true",
                     "forename": "asasd",
                     "surname": "dsfs",
                     "date_of_birth": "1956-05-05",
@@ -345,18 +343,24 @@ class PersonWithSignificantControlControllerValidationTest {
                 }
             }""";
 
-        private static final String JSON_FORENAME_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
-        private static final String JSON_SURNAME_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
-        private static final String JSON_DATE_OF_BIRTH_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": null, \"nationality1\": \"English\" }";
-        private static final String JSON_NATIONALITY1_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": null }";
-        private static final String JSON_FORENAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"§§§\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
-        private static final String JSON_FORMER_NAMES_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"former_names\": \"§§§\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
-        private static final String JSON_SURNAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"§§§\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
-        private static final String JSON_NATIONALITY1_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"§§§\" }";
-        private static final String JSON_NATIONALITY2_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\", \"nationality2\": \"§§§\" }";
-        private static final String JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
-        private static final String JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"surname\": \"" + TOO_MANY_CHARS + "\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
-        private static final String JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"forename\": \"Bob\", \"former_names\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_CONSENT_IS_REQUIRED_FALSE_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"false\", \"title\": \"Mr\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_CONSENT_IS_REQUIRED_NULL_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : null, \"title\": \"Mr\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_FORENAME_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_SURNAME_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_DATE_OF_BIRTH_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": null, \"nationality1\": \"English\" }";
+        private static final String JSON_NATIONALITY1_IS_REQUIRED_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": null }";
+        private static final String JSON_TITlE_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"§§§§\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_FORENAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"§§§\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_FORMER_NAMES_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"former_names\": \"§§§\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_MIDDLE_NAMES_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Fred\", \"middle_names\": \"§§§\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_SURNAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"§§§\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_NATIONALITY1_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"§§§\" }";
+        private static final String JSON_NATIONALITY2_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\", \"nationality2\": \"§§§\" }";
+        private static final String JSON_TITlE_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"" + TOO_MANY_CHARS + "\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Fred\", \"middle_names\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"" + TOO_MANY_CHARS + "\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
+        private static final String JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"former_names\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
 
 
         @ParameterizedTest
@@ -374,16 +378,22 @@ class PersonWithSignificantControlControllerValidationTest {
 
         @ParameterizedTest
         @CsvSource(value = {
+                JSON_CONSENT_IS_REQUIRED_FALSE_IP + "$ data.consentChecked $ Consent must be checked",
+                JSON_CONSENT_IS_REQUIRED_NULL_IP + "$ data.consentChecked $ Consent must be checked",
                 JSON_FORENAME_IS_REQUIRED_IP + "$ data.forename $ Forename is required",
                 JSON_SURNAME_IS_REQUIRED_IP + "$ data.surname $ Surname is required",
                 JSON_DATE_OF_BIRTH_IS_REQUIRED_IP + "$ data.dateOfBirth $ Date of birth is required",
                 JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ Nationality 1 is required",
+                JSON_TITlE_INVALID_CHARS_IP + "$ data.title $ Title " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
+                JSON_MIDDLE_NAMES_INVALID_CHARS_IP + "$ data.middleNames $ Middle names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
+                JSON_TITlE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
+                JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 160",
                 JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",
                 JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.formerNames $ Former names must be less than 160"
         }, delimiter = '$')
@@ -401,14 +411,19 @@ class PersonWithSignificantControlControllerValidationTest {
 
         @ParameterizedTest
         @CsvSource(value = {
+                JSON_CONSENT_IS_REQUIRED_FALSE_IP + "$ data.consentChecked $ Consent must be checked",
                 JSON_FORENAME_IS_REQUIRED_IP + "$ data.forename $ Forename is required",
                 JSON_SURNAME_IS_REQUIRED_IP + "$ data.surname $ Surname is required",
+                JSON_TITlE_INVALID_CHARS_IP + "$ data.title $ Title " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
+                JSON_MIDDLE_NAMES_INVALID_CHARS_IP + "$ data.middleNames $ Middle names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
+                JSON_TITlE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
+                JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 160",
                 JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",
                 JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.formerNames $ Former names must be less than 160"
         }, delimiter = '$')
@@ -424,7 +439,6 @@ class PersonWithSignificantControlControllerValidationTest {
                     .andExpect(jsonPath("$.['errors'].['" + field + "']").value(errorMessage));
         }
     }
-
 
     private void mocksPsc(PersonWithSignificantControlDao personWithSignificantControlDao) {
         when(repository.insert((PersonWithSignificantControlDao) any())).thenReturn(personWithSignificantControlDao);

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -391,9 +391,9 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
-                JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
-                JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
-                JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 160",
+                JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 50",
+                JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 50",
+                JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 50",
                 JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",
                 JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.formerNames $ Former names must be less than 160"
         }, delimiter = '$')
@@ -421,9 +421,9 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
                 JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
-                JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 160",
-                JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 160",
-                JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 160",
+                JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 50",
+                JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 50",
+                JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 50",
                 JSON_SURNAME_IS_ABOVE_MAX_CHARS_IP + "$ data.surname $ Surname must be less than 160",
                 JSON_FORMER_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.formerNames $ Former names must be less than 160"
         }, delimiter = '$')

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/PersonWithSignificantControlMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/PersonWithSignificantControlMapperTest.java
@@ -30,7 +30,6 @@ import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSig
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.REGISTERED_COMPANY_NUMBER;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.RESIGNATION_DATE;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.SERVICE_PREFIX;
-import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.SURNAME;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.URA_PREFIX;
 import static uk.gov.companieshouse.limitedpartnershipsapi.model.common.Country.ENGLAND;
 import static uk.gov.companieshouse.limitedpartnershipsapi.model.common.Nationality.BRITISH;
@@ -103,7 +102,7 @@ class PersonWithSignificantControlMapperTest {
                             BRITISH.getDescription(),
                             FRENCH.getDescription(),
                             RESIGNATION_DATE,
-                            SURNAME,
+                            "Smith",
                             PersonWithSignificantControlType.INDIVIDUAL_PERSON
                     );
 
@@ -150,7 +149,7 @@ class PersonWithSignificantControlMapperTest {
                             BRITISH.getDescription(),
                             FRENCH.getDescription(),
                             RESIGNATION_DATE,
-                            SURNAME,
+                            "Smith",
                             PersonWithSignificantControlType.INDIVIDUAL_PERSON
                     );
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/PersonWithSignificantControlMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/PersonWithSignificantControlMapperTest.java
@@ -22,6 +22,7 @@ import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSig
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.LEGAL_ENTITY_REGISTER_NAME;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.LEGAL_FORM;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.LOCALITY_SUFFIX;
+import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.MIDDLE_NAMES;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.NATURES_OF_CONTROL_LIST_DESCRIPTIONS;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.POA_PREFIX;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.POSTAL_CODE_SUFFIX;
@@ -30,6 +31,7 @@ import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSig
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.REGISTERED_COMPANY_NUMBER;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.RESIGNATION_DATE;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.SERVICE_PREFIX;
+import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.TITLE_MR;
 import static uk.gov.companieshouse.limitedpartnershipsapi.builder.PersonWithSignificantControlBuilder.URA_PREFIX;
 import static uk.gov.companieshouse.limitedpartnershipsapi.model.common.Country.ENGLAND;
 import static uk.gov.companieshouse.limitedpartnershipsapi.model.common.Nationality.BRITISH;
@@ -42,11 +44,14 @@ class PersonWithSignificantControlMapperTest {
 
     // Field name constants for extracting()
     private static final String FN_APPOINTMENT_ID = "appointmentId";
+    private static final String FN_CONSENT_CHECKED = "consentChecked";
     private static final String FN_COUNTRY = "country";
     private static final String FN_DATE_EFFECTIVE_FROM = "dateEffectiveFrom";
     private static final String FN_DATE_OF_BIRTH = "dateOfBirth";
+    private static final String FN_TITLE = "title";
     private static final String FN_FORENAME = "forename";
     private static final String FN_FORMER_NAMES = "formerNames";
+    private static final String FN_MIDDLE_NAMES = "middleNames";
     private static final String FN_GOVERNING_LAW = "governingLaw";
     private static final String FN_KIND = "kind";
     private static final String FN_LEGAL_ENTITY_NAME = "legalEntityName";
@@ -81,28 +86,34 @@ class PersonWithSignificantControlMapperTest {
             assertThat(dataDto)
                     .extracting(
                             FN_APPOINTMENT_ID,
+                            FN_CONSENT_CHECKED,
                             FN_DATE_EFFECTIVE_FROM,
                             FN_DATE_OF_BIRTH,
                             FN_FORENAME,
                             FN_FORMER_NAMES,
                             FN_KIND,
+                            FN_MIDDLE_NAMES,
                             FN_NATIONALITY1,
                             FN_NATIONALITY2,
                             FN_RESIGNATION_DATE,
                             FN_SURNAME,
+                            FN_TITLE,
                             FN_TYPE
                     )
                     .containsExactly(
                             APPOINTMENT_ID,
+                            true,
                             DATE_EFFECTIVE_FROM,
                             DATE_OF_BIRTH,
                             "John",
                             "Johnny",
                             FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL,
+                            MIDDLE_NAMES,
                             BRITISH.getDescription(),
                             FRENCH.getDescription(),
                             RESIGNATION_DATE,
                             "Smith",
+                            TITLE_MR,
                             PersonWithSignificantControlType.INDIVIDUAL_PERSON
                     );
 
@@ -128,28 +139,34 @@ class PersonWithSignificantControlMapperTest {
             assertThat(daoData)
                     .extracting(
                             FN_APPOINTMENT_ID,
+                            FN_CONSENT_CHECKED,
                             FN_DATE_EFFECTIVE_FROM,
                             FN_DATE_OF_BIRTH,
                             FN_FORENAME,
                             FN_FORMER_NAMES,
                             FN_KIND,
+                            FN_MIDDLE_NAMES,
                             FN_NATIONALITY1,
                             FN_NATIONALITY2,
                             FN_RESIGNATION_DATE,
                             FN_SURNAME,
+                            FN_TITLE,
                             FN_TYPE
                     )
                     .containsExactly(
                             APPOINTMENT_ID,
+                            true,
                             DATE_EFFECTIVE_FROM,
                             DATE_OF_BIRTH,
                             "John",
                             "Johnny",
                             FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL,
+                            MIDDLE_NAMES,
                             BRITISH.getDescription(),
                             FRENCH.getDescription(),
                             RESIGNATION_DATE,
                             "Smith",
+                            TITLE_MR,
                             PersonWithSignificantControlType.INDIVIDUAL_PERSON
                     );
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceTest.java
@@ -239,6 +239,39 @@ class PersonWithSignificantControlServiceTest {
     }
 
     @Test
+    void testUpdatePersonWithSignificantControlRemovesOptionalFieldsWhenPatchedToNull() throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
+        var pscUri = String.format(URL_GET_PERSON_WITH_SIGNIFICANT_CONTROL, TRANSACTION.getId(), PSC_ID);
+
+        PersonWithSignificantControlDao existingDao = new PersonWithSignificantControlBuilder().individualPersonDao();
+        PersonWithSignificantControlDto existingDto = new PersonWithSignificantControlBuilder().individualPersonDto();
+        PersonWithSignificantControlDataDto changesDataDto = new PersonWithSignificantControlDataDto();
+        changesDataDto.setForename("Bob");
+        changesDataDto.setSurname("Smith");
+        changesDataDto.setTitle(null);
+        changesDataDto.setMiddleNames(null);
+
+        PersonWithSignificantControlDao afterPatchDao = new PersonWithSignificantControlDao();
+
+        when(personWithSignificantControlValidator.getValidatorByType(any(PersonWithSignificantControlType.class))).thenReturn(personWithSignificantControlValidatorStrategy);
+        when(repository.findById(PSC_ID)).thenReturn(Optional.of(existingDao));
+        when(transactionService.isTransactionLinkedToResource(TRANSACTION, pscUri, FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL)).thenReturn(true);
+        when(mapper.daoToDto(existingDao)).thenReturn(existingDto);
+        when(mapper.dtoToDao(existingDto)).thenReturn(afterPatchDao);
+
+        assertNotNull(existingDto.getData().getTitle());
+        assertNotNull(existingDto.getData().getMiddleNames());
+
+        personWithSignificantControlService.updatePersonWithSignificantControl(TRANSACTION, PSC_ID, changesDataDto, REQUEST_ID, USER_ID);
+
+        verify(mapper, times(1)).update(changesDataDto, existingDto.getData());
+        verify(mapper, times(1)).dtoToDao(pscDtoCaptor.capture());
+
+        var capturedDto = pscDtoCaptor.getValue();
+        assertNull(capturedDto.getData().getTitle());
+        assertNull(capturedDto.getData().getMiddleNames());
+    }
+
+    @Test
     void testUpdatePersonWithSignificantControlNotFound() {
         when(repository.findById(PSC_ID)).thenReturn(Optional.empty());
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
@@ -226,6 +226,58 @@ class PersonWithSignificantControlServiceUpdateTest {
     }
 
     @Test
+    void shouldHandleIndividualPersonOptionalFields_shouldNotDelete() throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
+        PersonWithSignificantControlDao personWithSignificantControlDao = new PersonWithSignificantControlBuilder().individualPersonDao();
+
+        var preChangeTitle = personWithSignificantControlDao.getData().getTitle();
+        assertThat(preChangeTitle).isNotEmpty();
+
+        var preChangeMiddleNames = personWithSignificantControlDao.getData().getMiddleNames();
+        assertThat(preChangeMiddleNames).isNotEmpty();
+
+        PersonWithSignificantControlDataDto changesDto = new PersonWithSignificantControlDataDto();
+        changesDto.setNaturesOfControl(List.of(NatureOfControl.INDIVIDUAL_TRUST_CONTROL));
+
+        when(personWithSignificantControlRepository.findById(personWithSignificantControlDao.getId())).thenReturn(Optional.of(personWithSignificantControlDao));
+        when(transactionService.isTransactionLinkedToResource(any(), any(), any())).thenReturn(true);
+
+        personWithSignificantControlService.updatePersonWithSignificantControl(transaction, PSC_ID, changesDto, REQUEST_ID, USER_ID);
+
+        verify(personWithSignificantControlRepository).save(pscDaoArgumentCaptor.capture());
+        PersonWithSignificantControlDao savedPersonWithSignificantControlDao = pscDaoArgumentCaptor.getValue();
+        assertThat(savedPersonWithSignificantControlDao.getData().getTitle()).isEqualTo(preChangeTitle);
+        assertThat(savedPersonWithSignificantControlDao.getData().getMiddleNames()).isEqualTo(preChangeMiddleNames);
+    }
+
+    @Test
+    void shouldHandleIndividualPersonOptionalFields_shouldDelete() throws ServiceException, MethodArgumentNotValidException, NoSuchMethodException {
+        PersonWithSignificantControlDao personWithSignificantControlDao = new PersonWithSignificantControlBuilder().individualPersonDao();
+
+        var preChangeTitle = personWithSignificantControlDao.getData().getTitle();
+        assertThat(preChangeTitle).isNotEmpty();
+
+        var preChangeMiddleNames = personWithSignificantControlDao.getData().getMiddleNames();
+        assertThat(preChangeMiddleNames).isNotEmpty();
+
+        PersonWithSignificantControlDataDto changesDto = new PersonWithSignificantControlBuilder()
+                .withForename("John")
+                .withSurname("Doe")
+                .withTitle(null)
+                .withMiddleNames(null)
+                .individualPersonDto().getData();
+
+        when(personWithSignificantControlRepository.findById(personWithSignificantControlDao.getId())).thenReturn(Optional.of(personWithSignificantControlDao));
+        when(transactionService.isTransactionLinkedToResource(any(), any(), any())).thenReturn(true);
+
+        personWithSignificantControlService.updatePersonWithSignificantControl(transaction, PSC_ID, changesDto, REQUEST_ID, USER_ID);
+
+        verify(personWithSignificantControlRepository).save(pscDaoArgumentCaptor.capture());
+        PersonWithSignificantControlDao savedPersonWithSignificantControlDao = pscDaoArgumentCaptor.getValue();
+        assertThat(savedPersonWithSignificantControlDao.getData().getTitle()).isNull();
+        assertThat(savedPersonWithSignificantControlDao.getData().getMiddleNames()).isNull();
+    }
+
+    @Test
     void shouldThrowExceptionIfNotLinkedToTransaction() {
         PersonWithSignificantControlDao personWithSignificantControlDao = new PersonWithSignificantControlBuilder().individualPersonDao();
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1920


### Change description
This pull request enhances the handling of "Person with Significant Control" (PSC) data by introducing new fields, improving validation, and updating tests accordingly. The main changes include adding support for `consentChecked`, `title`, and `middleNames` fields for individuals, enforcing consent validation, and ensuring these fields are properly handled throughout the service and test layers.

**Enhancements to PSC data model and validation:**

* Added new fields `consentChecked`, `title`, and `middleNames` to both the DAO (`PersonWithSignificantControlDataDao`) and DTO (`PersonWithSignificantControlDataDto`) classes, including appropriate getters and setters. These fields are now part of the persisted and transferred PSC data. [[1]](diffhunk://#diff-75cdbb9fe89daa02c66bd6d364e6e161251f1efaef1d615df01ed0783ba63f6fR41-R52) [[2]](diffhunk://#diff-75cdbb9fe89daa02c66bd6d364e6e161251f1efaef1d615df01ed0783ba63f6fR277-R300) [[3]](diffhunk://#diff-2e2f1e49f1402a8ba46f4b6f33c32c6c0c927cb881286325f9a067179036c71dR57-R74) [[4]](diffhunk://#diff-2e2f1e49f1402a8ba46f4b6f33c32c6c0c927cb881286325f9a067179036c71dR322-R345)
* Enforced validation to require `consentChecked` to be true for individual persons, with corresponding error messaging if not provided or false.

**Service logic updates:**

* Updated the service layer to handle the new optional fields (`middleNames`, `title`) when updating PSC data, ensuring they are set to null if not provided in the update request. [[1]](diffhunk://#diff-a5872925ef7a55ba38ff5109496b392006a2439e425c3787cb1ad8abef0996b2R110) [[2]](diffhunk://#diff-a5872925ef7a55ba38ff5109496b392006a2439e425c3787cb1ad8abef0996b2R134-R145)

**Test and builder updates:**

* Extended the PSC test data builders to include the new fields, ensuring test coverage for the new data points. [[1]](diffhunk://#diff-efcbc73f757cfa0b61b41dd3a8e1d8fa2593535cf3858fa7e8383f60123ad304R29-R30) [[2]](diffhunk://#diff-efcbc73f757cfa0b61b41dd3a8e1d8fa2593535cf3858fa7e8383f60123ad304R120-R123) [[3]](diffhunk://#diff-efcbc73f757cfa0b61b41dd3a8e1d8fa2593535cf3858fa7e8383f60123ad304R208-R211)
* Updated controller validation tests to include scenarios for the new fields and consent validation, and refactored test JSON payloads accordingly. [[1]](diffhunk://#diff-af95699a8aeb288ea643a9abbbabbf81395dcbdfa51136b98809a5dda54c0e19R324) [[2]](diffhunk://#diff-af95699a8aeb288ea643a9abbbabbf81395dcbdfa51136b98809a5dda54c0e19R338-R363)
* Minor cleanup in test files, such as removing unused imports and object mappers. [[1]](diffhunk://#diff-350a95b2a30f7a6ac0a39a358b45a6d74cb20f82f03f1e4f0740bdf1e8b626e6L46) [[2]](diffhunk://#diff-2b557a2004866152d8e6c3405ab4b2df96165e62d4b8f824bf832db5a0ca7f8fL52) [[3]](diffhunk://#diff-af95699a8aeb288ea643a9abbbabbf81395dcbdfa51136b98809a5dda54c0e19L3) [[4]](diffhunk://#diff-af95699a8aeb288ea643a9abbbabbf81395dcbdfa51136b98809a5dda54c0e19L81-L83)

These changes improve the completeness and integrity of PSC data handling, ensuring new fields are consistently managed and properly validated throughout the application.


### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.