### PR TITLE
LP-1920 Add missing same nationality check

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/personwithsignificantcontrol/dto/PersonWithSignificantControlDataDto.java
@@ -87,11 +87,11 @@ public class PersonWithSignificantControlDataDto implements HasNationality {
     private LocalDate dateOfBirth;
 
     @JsonProperty("nationality1")
-    @EnumValid(message = "Nationality 1 must be valid")
+    @EnumValid(message = "First nationality must be valid")
     private Nationality nationality1;
 
     @JsonProperty("nationality2")
-    @EnumValid(message = "Nationality 2 must be valid")
+    @EnumValid(message = "Second nationality must be valid")
     private Nationality nationality2;
 
     @JsonProperty("usual_residential_address")

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
@@ -45,7 +45,11 @@ public class IndividualPersonValidatorStrategy extends PersonWithSignificantCont
         if (data.getDateOfBirth() == null) {
             addError("data.dateOfBirth", "Date of birth is required", bindingResult);
         }
-        checkNotNullOrEmpty(data.getNationality1(), "data.nationality1", "Nationality 1 is required", bindingResult);
+        checkNotNullOrEmpty(data.getNationality1(), "data.nationality1", "First nationality is required", bindingResult);
+
+        if (data.getNationality1() != null && data.getNationality1().equals(data.getNationality2())) {
+            addError("data.nationality2", "Second nationality must be different from the first", bindingResult);
+        }
 
         if (bindingResult.hasErrors()) {
             var methodParameter = new MethodParameter(PersonWithSignificantControlDataDto.class.getConstructor(), -1);

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -356,6 +356,7 @@ class PersonWithSignificantControlControllerValidationTest {
         private static final String JSON_SURNAME_INVALID_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"§§§\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_NATIONALITY1_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"§§§\" }";
         private static final String JSON_NATIONALITY2_INVALID_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\", \"nationality2\": \"§§§\" }";
+        private static final String JSON_NATIONALITIES_SAME_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Bob\", \"surname\": \"Smith\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\", \"nationality2\": \"English\" }";
         private static final String JSON_TITLE_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"" + TOO_MANY_CHARS + "\", \"forename\": \"Fred\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
         private static final String JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP = "{ \"kind\": \"limited-partnership#person-with-significant-control\", \"type\": \"INDIVIDUAL_PERSON\", \"consent_checked\" : \"true\", \"title\": \"Mr\", \"forename\": \"Fred\", \"middle_names\": \"" + TOO_MANY_CHARS + "\", \"surname\": \"dsfs\", \"date_of_birth\": \"1956-05-05\", \"nationality1\": \"English\" }";
@@ -383,14 +384,15 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_FORENAME_IS_REQUIRED_IP + "$ data.forename $ Forename is required",
                 JSON_SURNAME_IS_REQUIRED_IP + "$ data.surname $ Surname is required",
                 JSON_DATE_OF_BIRTH_IS_REQUIRED_IP + "$ data.dateOfBirth $ Date of birth is required",
-                JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ Nationality 1 is required",
+                JSON_NATIONALITY1_IS_REQUIRED_IP + "$ data.nationality1 $ First nationality is required",
                 JSON_TITLE_INVALID_CHARS_IP + "$ data.title $ Title " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORENAME_INVALID_CHARS_IP + "$ data.forename $ Forename " + INVALID_CHARACTERS_MESSAGE,
                 JSON_MIDDLE_NAMES_INVALID_CHARS_IP + "$ data.middleNames $ Middle names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
-                JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
-                JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
+                JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ First nationality must be valid",
+                JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Second nationality must be valid",
+                JSON_NATIONALITIES_SAME_IP + "$ data.nationality2 $ Second nationality must be different from the first",
                 JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 50",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 50",
                 JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 50",
@@ -419,8 +421,9 @@ class PersonWithSignificantControlControllerValidationTest {
                 JSON_MIDDLE_NAMES_INVALID_CHARS_IP + "$ data.middleNames $ Middle names " + INVALID_CHARACTERS_MESSAGE,
                 JSON_SURNAME_INVALID_CHARS_IP + "$ data.surname $ Surname " + INVALID_CHARACTERS_MESSAGE,
                 JSON_FORMER_NAMES_INVALID_CHARS_IP + "$ data.formerNames $ Former names " + INVALID_CHARACTERS_MESSAGE,
-                JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ Nationality 1 must be valid",
-                JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Nationality 2 must be valid",
+                JSON_NATIONALITY1_INVALID_IP + "$ data.nationality1 $ First nationality must be valid",
+                JSON_NATIONALITY2_INVALID_IP + "$ data.nationality2 $ Second nationality must be valid",
+                JSON_NATIONALITIES_SAME_IP + "$ data.nationality2 $ Second nationality must be different from the first",
                 JSON_TITLE_IS_ABOVE_MAX_CHARS_IP + "$ data.title $ Title must be less than 50",
                 JSON_FORENAME_IS_ABOVE_MAX_CHARS_IP + "$ data.forename $ Forename must be less than 50",
                 JSON_MIDDLE_NAMES_IS_ABOVE_MAX_CHARS_IP + "$ data.middleNames $ Middle names must be less than 50",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1920


### Change description
This pull request improves the validation logic and error messaging for the "nationality" fields in the Person With Significant Control (PSC) data model, ensuring clearer feedback and stricter validation rules. The main changes include updating error messages to be more descriptive, enforcing that the two nationality fields must be different, and adding corresponding test coverage.

Validation improvements:

* Updated validation error messages for `nationality1` and `nationality2` to refer to them as "First nationality" and "Second nationality" for clarity, both in the DTO annotations and in validation logic. [[1]](diffhunk://#diff-2e2f1e49f1402a8ba46f4b6f33c32c6c0c927cb881286325f9a067179036c71dL90-R94) [[2]](diffhunk://#diff-090380b70d821526569d66a43e951defa9390af673ea502f2b54193a36faa8acL48-R52)
* Added a new validation rule to ensure that `nationality2` cannot be the same as `nationality1`, with a specific error message if this occurs.

Test enhancements:

* Added a new test case (`JSON_NATIONALITIES_SAME_IP`) to verify that providing the same value for both nationality fields triggers the correct validation error.
* Updated test assertions to check for the new, more descriptive error messages and the new validation rule for distinct nationalities. [[1]](diffhunk://#diff-af95699a8aeb288ea643a9abbbabbf81395dcbdfa51136b98809a5dda54c0e19L386-R395) [[2]](diffhunk://#diff-af95699a8aeb288ea643a9abbbabbf81395dcbdfa51136b98809a5dda54c0e19L422-R426)


### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.