### PR TITLE
Feature/psc/lp 1934 ensure psc type cant be changed

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlService.java
@@ -100,9 +100,9 @@ public class PersonWithSignificantControlService {
         checkPersonWithSignificantControlIsLinkedToTransaction(transaction, personWithSignificantControlId, kind);
 
         var dto = mapper.daoToDto(daoBeforePatch);
+        var validator = personWithSignificantControlValidator.getValidatorByType(dto.getData().getType());
         mapper.update(personWithSignificantControlChangesDataDto, dto.getData());
 
-        var validator = personWithSignificantControlValidator.getValidatorByType(dto.getData().getType());
         validator.validatePartial(dto);
 
         NationalityUtils.handleSecondNationalityOptionality(personWithSignificantControlChangesDataDto, dto.getData());

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
@@ -9,6 +9,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.ServiceException;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.PersonWithSignificantControlType;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.validator.ValidationStatus;
@@ -34,6 +35,7 @@ public class IndividualPersonValidatorStrategy extends PersonWithSignificantCont
         BindingResult bindingResult = new BeanPropertyBindingResult(personWithSignificantControlDto, DATA_DTO_CLASS_NAME);
 
         performAnnotationValidation(personWithSignificantControlDto, validator, bindingResult);
+        super.checkPersonWithSignificantControlTypeAlreadySet(personWithSignificantControlDto.getData(), PersonWithSignificantControlType.INDIVIDUAL_PERSON, bindingResult);
 
         // null checks for mandatory fields
         var data = personWithSignificantControlDto.getData();

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/IndividualPersonValidatorStrategy.java
@@ -35,7 +35,7 @@ public class IndividualPersonValidatorStrategy extends PersonWithSignificantCont
         BindingResult bindingResult = new BeanPropertyBindingResult(personWithSignificantControlDto, DATA_DTO_CLASS_NAME);
 
         performAnnotationValidation(personWithSignificantControlDto, validator, bindingResult);
-        super.checkPersonWithSignificantControlTypeAlreadySet(personWithSignificantControlDto.getData(), PersonWithSignificantControlType.INDIVIDUAL_PERSON, bindingResult);
+        super.checkPersonWithSignificantControlTypeUnchanged(personWithSignificantControlDto.getData(), PersonWithSignificantControlType.INDIVIDUAL_PERSON, bindingResult);
 
         // null checks for mandatory fields
         var data = personWithSignificantControlDto.getData();

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/OtherRegistrablePersonValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/OtherRegistrablePersonValidatorStrategy.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.ServiceException;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.PersonWithSignificantControlType;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.validator.ValidationStatus;
 
@@ -26,7 +27,7 @@ public class OtherRegistrablePersonValidatorStrategy extends PersonWithSignifica
 
     @Override
     public void validatePartial(PersonWithSignificantControlDto personWithSignificantControlDto) throws NoSuchMethodException, MethodArgumentNotValidException, ServiceException {
-       super.validatePartialRleOrOrp(personWithSignificantControlDto, validator);
+        super.validatePartialRleOrOrp(personWithSignificantControlDto, validator, PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
@@ -91,7 +91,7 @@ public abstract class PersonWithSignificantControlValidatorStrategy {
     }
 
 
-    protected void checkPersonWithSignificantControlTypeAlreadySet(PersonWithSignificantControlDataDto dataDto, PersonWithSignificantControlType expectedType, BindingResult bindingResult) throws NoSuchMethodException, MethodArgumentNotValidException {
+    protected void checkPersonWithSignificantControlTypeAlreadySet(PersonWithSignificantControlDataDto dataDto, PersonWithSignificantControlType expectedType, BindingResult bindingResult) {
         var type = dataDto.getType();
         if (type != null && type != expectedType) {
             addError("data.type", "Person with significant control type cannot be changed", bindingResult);

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
@@ -54,7 +54,7 @@ public abstract class PersonWithSignificantControlValidatorStrategy {
         BindingResult bindingResult = new BeanPropertyBindingResult(personWithSignificantControlDto, DATA_DTO_CLASS_NAME);
 
         performAnnotationValidation(personWithSignificantControlDto, validator, bindingResult);
-        checkPersonWithSignificantControlTypeAlreadySet(personWithSignificantControlDto.getData(), expectedType, bindingResult);
+        checkPersonWithSignificantControlTypeUnchanged(personWithSignificantControlDto.getData(), expectedType, bindingResult);
 
         // null checks for mandatory fields
         var data = personWithSignificantControlDto.getData();
@@ -91,7 +91,7 @@ public abstract class PersonWithSignificantControlValidatorStrategy {
     }
 
 
-    protected void checkPersonWithSignificantControlTypeAlreadySet(PersonWithSignificantControlDataDto dataDto, PersonWithSignificantControlType expectedType, BindingResult bindingResult) {
+    protected void checkPersonWithSignificantControlTypeUnchanged(PersonWithSignificantControlDataDto dataDto, PersonWithSignificantControlType expectedType, BindingResult bindingResult) {
         var type = dataDto.getType();
         if (type != null && type != expectedType) {
             addError("data.type", "Person with significant control type cannot be changed", bindingResult);

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/PersonWithSignificantControlValidatorStrategy.java
@@ -10,6 +10,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.ServiceException;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.PersonWithSignificantControlType;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.validator.ValidationStatus;
@@ -49,10 +50,11 @@ public abstract class PersonWithSignificantControlValidatorStrategy {
         }
     }
 
-    protected void validatePartialRleOrOrp(PersonWithSignificantControlDto personWithSignificantControlDto, Validator validator) throws NoSuchMethodException, MethodArgumentNotValidException {
+    protected void validatePartialRleOrOrp(PersonWithSignificantControlDto personWithSignificantControlDto, Validator validator, PersonWithSignificantControlType expectedType) throws NoSuchMethodException, MethodArgumentNotValidException {
         BindingResult bindingResult = new BeanPropertyBindingResult(personWithSignificantControlDto, DATA_DTO_CLASS_NAME);
 
         performAnnotationValidation(personWithSignificantControlDto, validator, bindingResult);
+        checkPersonWithSignificantControlTypeAlreadySet(personWithSignificantControlDto.getData(), expectedType, bindingResult);
 
         // null checks for mandatory fields
         var data = personWithSignificantControlDto.getData();
@@ -85,6 +87,14 @@ public abstract class PersonWithSignificantControlValidatorStrategy {
             validationStatus.convertFieldErrorsToValidationStatusErrors(e.getBindingResult(), errorsList);
         } catch (NoSuchMethodException e) {
             throw new ServiceException(e.getMessage());
+        }
+    }
+
+
+    protected void checkPersonWithSignificantControlTypeAlreadySet(PersonWithSignificantControlDataDto dataDto, PersonWithSignificantControlType expectedType, BindingResult bindingResult) throws NoSuchMethodException, MethodArgumentNotValidException {
+        var type = dataDto.getType();
+        if (type != null && type != expectedType) {
+            addError("data.type", "Person with significant control type cannot be changed", bindingResult);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/RelevantLegalEntityValidatorStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/service/validator/personwithsignificantcontrol/RelevantLegalEntityValidatorStrategy.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.ServiceException;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.PersonWithSignificantControlType;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.service.validator.ValidationStatus;
 
@@ -26,7 +27,7 @@ public class RelevantLegalEntityValidatorStrategy extends PersonWithSignificantC
 
     @Override
     public void validatePartial(PersonWithSignificantControlDto personWithSignificantControlDto) throws NoSuchMethodException, MethodArgumentNotValidException, ServiceException {
-       super.validatePartialRleOrOrp(personWithSignificantControlDto, validator);
+        super.validatePartialRleOrOrp(personWithSignificantControlDto, validator, PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY);
     }
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
@@ -3,6 +3,9 @@ package uk.gov.companieshouse.limitedpartnershipsapi.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,12 +23,14 @@ import uk.gov.companieshouse.limitedpartnershipsapi.model.common.Nationality;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.dao.AddressDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.common.dto.AddressDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.NatureOfControl;
+import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.PersonWithSignificantControlType;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dao.PersonWithSignificantControlDao;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.personwithsignificantcontrol.dto.PersonWithSignificantControlDataDto;
 import uk.gov.companieshouse.limitedpartnershipsapi.repository.PersonWithSignificantControlRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -36,6 +41,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL;
+import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.INVALID_CHARACTERS_MESSAGE;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_PERSON_WITH_SIGNIFICANT_CONTROL;
 
 @ExtendWith(MockitoExtension.class)
@@ -289,5 +295,43 @@ class PersonWithSignificantControlServiceUpdateTest {
         assertThatThrownBy(() -> personWithSignificantControlService.updatePersonWithSignificantControl(transaction, PSC_ID, personWithSignificantControlDataDto, REQUEST_ID, USER_ID))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining(String.format("Transaction id: %s does not have a resource that matches person with significant control id: %s", transaction.getId(), PSC_ID));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIncorrectTypeUpdateCases")
+    void shouldReturnErrorIfUpdateAttemptedWithIncorrectType(
+            PersonWithSignificantControlDao existingDao,
+            PersonWithSignificantControlDataDto dto,
+            PersonWithSignificantControlType incorrectType
+    ) {
+        dto.setType(incorrectType);
+
+        when(personWithSignificantControlRepository.findById(PSC_ID)).thenReturn(Optional.of(existingDao));
+        when(transactionService.isTransactionLinkedToResource(any(), any(), any())).thenReturn(true);
+
+        assertThatThrownBy(() -> personWithSignificantControlService.updatePersonWithSignificantControl(
+                transaction, PSC_ID, dto, REQUEST_ID, USER_ID))
+                .isInstanceOf(MethodArgumentNotValidException.class)
+                .hasMessageContaining("Person with significant control type cannot be changed");
+    }
+
+    private static Stream<Arguments> provideIncorrectTypeUpdateCases() {
+        return Stream.of(
+                org.junit.jupiter.params.provider.Arguments.of(
+                        new PersonWithSignificantControlBuilder().individualPersonDao(),
+                        new PersonWithSignificantControlBuilder().individualPersonDto().getData(),
+                        PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY
+                ),
+                org.junit.jupiter.params.provider.Arguments.of(
+                        new PersonWithSignificantControlBuilder().relevantLegalEntityDao(),
+                        new PersonWithSignificantControlBuilder().relevantLegalEntityDto().getData(),
+                        PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON
+                ),
+                org.junit.jupiter.params.provider.Arguments.of(
+                        new PersonWithSignificantControlBuilder().otherRegistrablePersonDao(),
+                        new PersonWithSignificantControlBuilder().otherRegistrablePersonDto().getData(),
+                        PersonWithSignificantControlType.INDIVIDUAL_PERSON
+                )
+        );
     }
 }

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
@@ -41,7 +41,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_PERSON_WITH_SIGNIFICANT_CONTROL;
-import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.INVALID_CHARACTERS_MESSAGE;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.URL_GET_PERSON_WITH_SIGNIFICANT_CONTROL;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PersonWithSignificantControlServiceUpdateTest.java
@@ -316,17 +316,17 @@ class PersonWithSignificantControlServiceUpdateTest {
 
     private static Stream<Arguments> provideIncorrectTypeUpdateCases() {
         return Stream.of(
-                org.junit.jupiter.params.provider.Arguments.of(
+                Arguments.of(
                         new PersonWithSignificantControlBuilder().individualPersonDao(),
                         new PersonWithSignificantControlBuilder().individualPersonDto().getData(),
                         PersonWithSignificantControlType.RELEVANT_LEGAL_ENTITY
                 ),
-                org.junit.jupiter.params.provider.Arguments.of(
+                Arguments.of(
                         new PersonWithSignificantControlBuilder().relevantLegalEntityDao(),
                         new PersonWithSignificantControlBuilder().relevantLegalEntityDto().getData(),
                         PersonWithSignificantControlType.OTHER_REGISTRABLE_PERSON
                 ),
-                org.junit.jupiter.params.provider.Arguments.of(
+                Arguments.of(
                         new PersonWithSignificantControlBuilder().otherRegistrablePersonDao(),
                         new PersonWithSignificantControlBuilder().otherRegistrablePersonDto().getData(),
                         PersonWithSignificantControlType.INDIVIDUAL_PERSON


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1934


### Change description
Ensure that PSC type (INDIVIDUAL_PERSON, OTHER_REGISTRABLE_PERSON, RELEVANT_LEGAL_ENTITY) can't be changed during patch.

Moved getValidatorByType call before we update dto with changesDto to ensure we check the correct type.

### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.