### PR TITLE
Upgrade to spring 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <!--  Sonar -->
         <sonar.projectName>limited-partnerships-api</sonar.projectName>
         <sonar.projectKey>uk.gov.companieshouse:limited-partnerships-api</sonar.projectKey>
+        <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
         <sonar.password></sonar.password>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <api-sdk-java.version>6.6.11</api-sdk-java.version>
         <structured-logging.version>3.0.37</structured-logging.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
-        <log4j.version>2.25.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
         <api-security-java.version>2.0.10</api-security-java.version>
@@ -85,6 +85,22 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- override -->
+        <!-- override tomcat-embed-core to fix CWE-20 - transitive dependency from spring-boot-starter-web 4.0.6 -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>11.0.22</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- override tomcat-embed-websocket to fix CWE-20 - transitive dependency from spring-boot-starter-web 4.0.6 -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>11.0.22</version>
+            <scope>compile</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -101,11 +117,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-boot-dependencies.version>3.5.11</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.5</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>4.0.6</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>
         <api-sdk-java.version>6.6.11</api-sdk-java.version>
         <structured-logging.version>3.0.37</structured-logging.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
@@ -35,6 +35,9 @@
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
         <encoder.version>1.3.1</encoder.version>
         <skip.unit.tests>false</skip.unit.tests>
+
+        <!-- Testcontainers -->
+        <testcontainers.version>1.20.1</testcontainers.version>
 
         <!--  Sonar -->
         <sonar.projectName>limited-partnerships-api</sonar.projectName>
@@ -69,6 +72,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -147,6 +157,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
         <sonar.projectName>limited-partnerships-api</sonar.projectName>
         <sonar.projectKey>uk.gov.companieshouse:limited-partnerships-api</sonar.projectKey>
         <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
+        <plexus-utils.version>4.0.3</plexus-utils.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
         <sonar.password></sonar.password>
@@ -181,6 +183,18 @@
             <artifactId>sonar-maven-plugin</artifactId>
             <version>${sonar-maven-plugin.version}</version>
             <scope>test</scope>
+        </dependency>
+        <!-- Fixes vulnerabilities for sonar plugins -->
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus-utils.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/JacksonConfig.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/JacksonConfig.java
@@ -12,7 +12,7 @@ public class JacksonConfig {
     @Bean
     ObjectMapper objectMapper() {
         var mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.ALWAYS)
+        mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS)
                 .registerModule(new JsonNullableModule());
         return mapper;
     }

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/JacksonConfig.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/config/JacksonConfig.java
@@ -1,19 +1,19 @@
 package uk.gov.companieshouse.limitedpartnershipsapi.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 @Configuration
 public class JacksonConfig {
 
     @Bean
-    Jackson2ObjectMapperBuilder objectMapperBuilder() {
-        var builder = new Jackson2ObjectMapperBuilder();
-        builder.serializationInclusion(JsonInclude.Include.ALWAYS)
-                .modulesToInstall(new JsonNullableModule());
-        return builder;
+    ObjectMapper objectMapper() {
+        var mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.ALWAYS)
+                .registerModule(new JsonNullableModule());
+        return mapper;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 limited_partnerships.mongodb.dbname=transactions_limited_partnerships
-spring.data.mongodb.uri=${MONGODB_URL}/${limited_partnerships.mongodb.dbname}
-
+spring.mongodb.uri=${MONGODB_URL}/${limited_partnerships.mongodb.dbname}
 # Spring actuator end-points config
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/ControllerEndpointInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/config/ControllerEndpointInterceptorTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/FilingsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/FilingsControllerTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerUpdateTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/GeneralPartnerControllerValidationTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerUpdateTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/IncorporationControllerValidationTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerValidationTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerUpdateTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PartnershipControllerValidationTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.limitedpartnershipsapi.builder.LimitedPartnershipBuilder;
 import uk.gov.companieshouse.limitedpartnershipsapi.builder.TransactionBuilder;
+import uk.gov.companieshouse.limitedpartnershipsapi.config.JacksonConfig;
 import uk.gov.companieshouse.limitedpartnershipsapi.exception.GlobalExceptionHandler;
 import uk.gov.companieshouse.limitedpartnershipsapi.mapper.LimitedPartnershipMapperImpl;
 import uk.gov.companieshouse.limitedpartnershipsapi.mapper.LimitedPartnershipPatchMapperImpl;
@@ -68,7 +69,8 @@ import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.INVAL
         LimitedPartnershipMapperImpl.class,
         LimitedPartnershipPatchMapperImpl.class,
         CostsService.class,
-        GlobalExceptionHandler.class
+        GlobalExceptionHandler.class,
+        JacksonConfig.class
 })
 @WebMvcTest(controllers = {PartnershipController.class})
 class PartnershipControllerValidationTest {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/PersonWithSignificantControlControllerValidationTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipPatchMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipPatchMapperTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.Jurisdiction;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.PartnershipNameEnding;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipPatchMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/mapper/LimitedPartnershipPatchMapperTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.Jurisdiction;
 import uk.gov.companieshouse.limitedpartnershipsapi.model.partnership.PartnershipNameEnding;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * In many of these tests, it's only necessary to test with one of the JsonNullable fields in the Patch class changing
  * as the behaviour should be the same for all of them.
  */
+
 @SpringBootTest
 class LimitedPartnershipPatchMapperTest {
 

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/GeneralPartnerRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/GeneralPartnerRepositoryTest.java
@@ -31,7 +31,7 @@ class GeneralPartnerRepositoryTest {
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("spring.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/LimitedPartnerRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/LimitedPartnerRepositoryTest.java
@@ -24,7 +24,7 @@ class LimitedPartnerRepositoryTest {
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("spring.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/LimitedPartnershipIncorporationRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/LimitedPartnershipIncorporationRepositoryTest.java
@@ -24,7 +24,7 @@ class LimitedPartnershipIncorporationRepositoryTest {
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("spring.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/LimitedPartnershipRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/LimitedPartnershipRepositoryTest.java
@@ -24,7 +24,7 @@ class LimitedPartnershipRepositoryTest {
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("spring.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/PersonWithSignificantControlRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/repository/PersonWithSignificantControlRepositoryTest.java
@@ -30,7 +30,7 @@ class PersonWithSignificantControlRepositoryTest {
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("spring.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
     }
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceContainerTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceContainerTest.java
@@ -25,7 +25,7 @@ import uk.gov.companieshouse.limitedpartnershipsapi.model.generalpartner.dto.Gen
 import java.time.LocalDate;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_GENERAL_PARTNER;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceContainerTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/GeneralPartnerServiceContainerTest.java
@@ -40,7 +40,7 @@ class GeneralPartnerServiceContainerTest {
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("spring.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
     }
 
     Transaction transaction = new TransactionBuilder().withKindAndUri(

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PostTransitionPartnerTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PostTransitionPartnerTest.java
@@ -29,9 +29,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.limitedpartnershipsapi.utils.Constants.FILING_KIND_GENERAL_PARTNER;

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PostTransitionPartnershipTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/service/PostTransitionPartnershipTest.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
### Change description
This pull request makes several key updates to dependencies, test configuration, and MongoDB connection settings to support Spring Boot 4.x and address security and compatibility concerns. The most significant changes are grouped below:

**Dependency and Build Updates:**

- Upgraded `spring-boot-dependencies` and `spring-boot-maven-plugin` to version 4.0.6, and updated `log4j` to 2.25.4 for improved compatibility and security.
- Added and updated dependencies for `testcontainers`, `plexus-utils`, and `bouncycastle`, and introduced overrides for `tomcat-embed-core` and `tomcat-embed-websocket` to address transitive vulnerabilities. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R39-R47) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R81-R106) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R176-R198)
- Removed the `spring-boot-devtools` dependency.

**Spring Boot 4.x Test Configuration Migration:**

- Replaced usages of `org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest` and related annotations with their new Spring Boot 4.x equivalents from `org.springframework.boot.webmvc.test.autoconfigure`. This affects multiple test files. [[1]](diffhunk://#diff-2e5a848367b7b314f91cc0ed3bbbb17126d359ef234703705fca579acdb434eeL8-R8) [[2]](diffhunk://#diff-2061bf22f3c6a62ac5fed72e7b4130fd4a1f4bdc297feaeb3d03bf3e4b6679f1L7-R7) [[3]](diffhunk://#diff-350a95b2a30f7a6ac0a39a358b45a6d74cb20f82f03f1e4f0740bdf1e8b626e6L11-R11) [[4]](diffhunk://#diff-a3f84a9bcfee1eac20111361072e1e9237de8e68fd1fea30f43a24a5cde9606bL9-R9) [[5]](diffhunk://#diff-06d164e6c250c3a3844ca5c849f0b45efc6aaccc2c73deeccab4a6156cf69a5dL7-R7) [[6]](diffhunk://#diff-944d6cce3b48e2a46eec89709bd8f32277b0268c0dd1a63bddca65389f1fa584L9-R9) [[7]](diffhunk://#diff-2b557a2004866152d8e6c3405ab4b2df96165e62d4b8f824bf832db5a0ca7f8fL12-R12) [[8]](diffhunk://#diff-ed897c95c224b506a656e6a129a8e81a0aca86355002922e922757a8d3da5398L9-R9) [[9]](diffhunk://#diff-649b7b053fc959d8c869e4d19af14a019b42cd47fa430915250c87498e811112L8-R8) [[10]](diffhunk://#diff-5fa5ec9c752afa41f98bf40a521c66232f50a7965d0bb59bbbd5b9a64e59c956L14-R14) [[11]](diffhunk://#diff-af95699a8aeb288ea643a9abbbabbf81395dcbdfa51136b98809a5dda54c0e19L10-R10)

**MongoDB Configuration Changes:**

- Updated MongoDB connection property from `spring.data.mongodb.uri` to `spring.mongodb.uri` in `application.properties` and all related test classes to align with the new Spring Boot 4.x conventions. [[1]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L2-R2) [[2]](diffhunk://#diff-8e6223f38567bee0090b9d63c8598a347d90d2b71e0eb3bca1429b9250dbbbd0L34-R34) [[3]](diffhunk://#diff-835f6fc33625982e5e9657f7d36c8876abfabf4a82fe775578b457ef8dade413L27-R27) [[4]](diffhunk://#diff-d5fa9b7755fb3d893ee1b19c49c547b4731451d4ff3313466e7a3d3164bf0aa3L27-R27) [[5]](diffhunk://#diff-4fcfa0a7151a13c05c2db40612f062fa09c3c633b2a67be14ebb9cdc5096dcc9L27-R27) [[6]](diffhunk://#diff-1d239f9a48e29cf2e981a12a5ef740008e25de312fa75f98d9eae5d62762bfc9L33-R33)

**Jackson Configuration Update:**

- Changed the Jackson configuration bean to provide a plain `ObjectMapper` instead of a `Jackson2ObjectMapperBuilder` due to deprecation, and updated its registration of modules.

**Test and Bean Registration Adjustments:**

- Registered `JacksonConfig` as a bean in relevant test contexts to ensure proper serialization configuration. [[1]](diffhunk://#diff-5fa5ec9c752afa41f98bf40a521c66232f50a7965d0bb59bbbd5b9a64e59c956R24) [[2]](diffhunk://#diff-5fa5ec9c752afa41f98bf40a521c66232f50a7965d0bb59bbbd5b9a64e59c956L71-R73)
- Added the `spring-boot-starter-webmvc-test` dependency for improved test support.

These changes collectively modernize the project for Spring Boot 4.x, improve test reliability, and address important security and compatibility issues.


### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.