### PR TITLE
Add Macedonia to country enum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <api-sdk-manager-java-library.version>3.0.18</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
         <encoder.version>1.3.1</encoder.version>
+        <io.opentelemetry.version>1.62.0</io.opentelemetry.version>
+        <tomcat.version>11.0.22</tomcat.version>
         <skip.unit.tests>false</skip.unit.tests>
 
         <!-- Testcontainers -->
@@ -85,25 +87,28 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- override -->
+            <!-- override tomcat-embed-core to fix CWE-20 - transitive dependency from spring-boot-starter-web 4.0.6 -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <!-- override tomcat-embed-websocket to fix CWE-20 - transitive dependency from spring-boot-starter-web 4.0.6 -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <!-- override transitive opentelemetry-api to fix CVE-2026-45292 -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>${io.opentelemetry.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
-        <!-- override -->
-        <!-- override tomcat-embed-core to fix CWE-20 - transitive dependency from spring-boot-starter-web 4.0.6 -->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.22</version>
-            <scope>compile</scope>
-        </dependency>
-        <!-- override tomcat-embed-websocket to fix CWE-20 - transitive dependency from spring-boot-starter-web 4.0.6 -->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-websocket</artifactId>
-            <version>11.0.22</version>
-            <scope>compile</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/common/Country.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/common/Country.java
@@ -138,6 +138,7 @@ public enum Country {
     LITHUANIA("Lithuania"),
     LUXEMBOURG("Luxembourg"),
     MACAO("Macao"),
+    MACEDONIA("Macedonia"),
     MADAGASCAR("Madagascar"),
     MALAWI("Malawi"),
     MALAYSIA("Malaysia"),


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2021


### Change description
**Codebase Updates:**

* Added `MACEDONIA` to the `Country` enum in `Country.java`.

This pull request updates dependencies in the `pom.xml` to address security vulnerabilities and improve maintainability, and also adds a new country to the `Country` enum. The main changes are as follows:

**Dependency Management and Security:**

* Introduced new properties for `io.opentelemetry.version` and `tomcat.version` in `pom.xml` to centralize version management and facilitate easier updates.
* Updated Tomcat dependencies (`tomcat-embed-core` and `tomcat-embed-websocket`) to use the new `${tomcat.version}` property, ensuring consistency and simplifying future upgrades.
* Added an explicit override for the `opentelemetry-api` dependency with a specific version to address CVE-2026-45292.

### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.