### PR TITLE
LP-2027: Match capital contribution max length to CHIPS

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/limitedpartner/dto/LimitedPartnerDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/model/limitedpartner/dto/LimitedPartnerDataDto.java
@@ -24,7 +24,7 @@ public class LimitedPartnerDataDto extends PartnerDataDto {
 
     @JsonProperty(CONTRIBUTION_CURRENCY_VALUE_FIELD)
     @Pattern(regexp = "^\\d+(\\.\\d{2})$", message = "Contribution currency value must be a valid decimal number")
-    @Size(max = 15, message = "The capital contribution value cannot have more than 12 digits before the decimal")
+    @Size(max = 11, message = "The capital contribution value cannot have more than 8 digits before the decimal")
     private String contributionCurrencyValue;
 
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/controller/LimitedPartnerControllerUpdateTest.java
@@ -271,6 +271,7 @@ class LimitedPartnerControllerUpdateTest {
         private static final String JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_MANY_DECIMAL_PLACES = "{ \"forename\": \"Joe\", \"former_names\": \"\", \"surname\": \"Bloggs\", \"date_of_birth\": \"2001-01-01\", \"nationality1\": \"BRITISH\", \"nationality2\": null, \"contribution_currency_type\":  \"GBP\", \"contribution_currency_value\": \"0.123456789\", \"contribution_sub_types\": \"SHARES\" }";
         private static final String JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_NO_DECIMAL_PLACES = "{ \"forename\": \"Joe\", \"former_names\": \"\", \"surname\": \"Bloggs\", \"date_of_birth\": \"2001-01-01\", \"nationality1\": \"BRITISH\", \"nationality2\": null, \"contribution_currency_type\":  \"GBP\", \"contribution_currency_value\": \"12345\", \"contribution_sub_types\": \"SHARES\" }";
         private static final String JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_TOO_MANY_NUMBERS = "{ \"forename\": \"Joe\", \"former_names\": \"\", \"surname\": \"Bloggs\", \"date_of_birth\": \"2001-01-01\", \"nationality1\": \"BRITISH\", \"nationality2\": null, \"contribution_currency_type\":  \"GBP\", \"contribution_currency_value\": \"5000000000000.00\", \"contribution_sub_types\": \"SHARES\" }";
+        private static final String JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_NINE_DIGITS = "{ \"forename\": \"Joe\", \"former_names\": \"\", \"surname\": \"Bloggs\", \"date_of_birth\": \"2001-01-01\", \"nationality1\": \"BRITISH\", \"nationality2\": null, \"contribution_currency_type\":  \"GBP\", \"contribution_currency_value\": \"100000000.00\", \"contribution_sub_types\": \"SHARES\" }";
 
         @ParameterizedTest
         @ValueSource(strings = {
@@ -301,7 +302,8 @@ class LimitedPartnerControllerUpdateTest {
             JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_CHARACTER + "$ data.contributionCurrencyValue $ Contribution currency value must be a valid decimal number",
             JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_MANY_DECIMAL_PLACES + "$ data.contributionCurrencyValue $ Contribution currency value must be a valid decimal number",
             JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_NO_DECIMAL_PLACES + "$ data.contributionCurrencyValue $ Contribution currency value must be a valid decimal number",
-            JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_TOO_MANY_NUMBERS + "$ data.contributionCurrencyValue $ The capital contribution value cannot have more than 12 digits before the decimal",
+            JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_TOO_MANY_NUMBERS + "$ data.contributionCurrencyValue $ The capital contribution value cannot have more than 8 digits before the decimal",
+            JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_AMOUNT_NINE_DIGITS + "$ data.contributionCurrencyValue $ The capital contribution value cannot have more than 8 digits before the decimal",
             JSON_PERSON_INVALID_CAPITAL_CONTRIBUTION_TYPE + "$ data.contributionSubTypes $ Capital contribution type must be valid"}, delimiter = '$')
         void shouldReturn400(String body, String field, String errorMessage) throws Exception {
             mocks();


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-2027


### Change description
Match capital contribution max length to CHIPS (8 integer digits)


### Work checklist

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.