### PR TITLE
LP-1812 Fix - don't include nationality when not changed in update person

### DIFF
--- a/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/filings/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/limitedpartnershipsapi/filings/FilingsService.java
@@ -327,8 +327,13 @@ public class FilingsService {
 
         var partnerNationality1 = StringUtils.trim(partnerDataDto.getNationality1());
         var partnerNationality2 = StringUtils.trim(partnerDataDto.getNationality2());
-        Boolean nationality1Changed = partnerNationality1 != null && !partnerNationality1.equalsIgnoreCase(appointmentNationality1);
-        Boolean nationality2Changed = partnerNationality2 == null || !partnerNationality2.equalsIgnoreCase(appointmentNationality2);
+
+        boolean nationality1Changed = (partnerNationality1 == null)
+                ? appointmentNationality1 != null
+                : !partnerNationality1.equalsIgnoreCase(appointmentNationality1);
+        boolean nationality2Changed = (partnerNationality2 == null)
+                ? appointmentNationality2 != null
+                : !partnerNationality2.equalsIgnoreCase(appointmentNationality2);
 
         if (nationality1Changed || nationality2Changed) {
             if (partnerNationality1 == null) {

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/filings/FilingsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/filings/FilingsServiceTest.java
@@ -777,6 +777,240 @@ class FilingsServiceTest {
 
             assertEquals(today, filingLimitedPartnerDataDto.getCeaseDate());
         }
+
+
+        /**
+         * Tests for the nationality1Changed and nationality2Changed boolean logic
+         * in setNationalitiesFields method.
+         *
+         * Truth table:
+         * | partnerNationality1 | appointmentNationality1 | Expected nationality1Changed |
+         * |---------------------|-------------------------|------------------------------|
+         * | null                | null                    | false (unchanged)            |
+         * | null                | "British"               | true (changed)               |
+         * | "British"           | null                    | true (changed)               |
+         * | "British"           | "British"               | false (unchanged)            |
+         * | "British"           | "british" (diff case)   | false (unchanged)            |
+         * | "British"           | "French"                | true (changed)               |
+         */
+
+        @Test
+        void testNationality1Changed_BothNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            mockChsAppointmentApiData(true, null);
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(null)
+                    .withNationality2(null)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertNull(filingLimitedPartnerDataDto.getNationality1());
+            assertNull(filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality1Changed_PartnerNullAppointmentNonNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            // Appointment previously had "British" for nationality1, partner has none set.
+            // Removing nationality1 is not allowed, so both fields are nulled out (no update sent).
+            mockChsAppointmentApiData(true, "British");
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(null)
+                    .withNationality2(null)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertNull(filingLimitedPartnerDataDto.getNationality1());
+            assertNull(filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality1Changed_PartnerNonNullAppointmentNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            // Appointment has no nationality recorded, partner sets nationality1 to "British".
+            // This is a genuine change, so the partner's target value is output.
+            mockChsAppointmentApiData(true, null);
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(Nationality.BRITISH)
+                    .withNationality2(null)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
+            assertNull(filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality1Changed_BothSame() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            mockChsAppointmentApiData(true, "British,French");
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(Nationality.BRITISH)
+                    .withNationality2(Nationality.FRENCH)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertNull(filingLimitedPartnerDataDto.getNationality1());
+            assertNull(filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality1Changed_CaseInsensitiveComparison() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            mockChsAppointmentApiData(true, "british,french");
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(Nationality.BRITISH)
+                    .withNationality2(Nationality.FRENCH)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertNull(filingLimitedPartnerDataDto.getNationality1());
+            assertNull(filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality1Changed_DifferentValues() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            // Appointment previously had French/Spanish, partner target is British/Irish.
+            // Output should reflect the partner's NEW target values, not the appointment's old ones.
+            mockChsAppointmentApiData(true, "French,Spanish");
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(Nationality.BRITISH)
+                    .withNationality2(Nationality.IRISH)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
+            assertEquals("Irish", filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality2Changed_BothNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            // Appointment previously had only nationality1 ("British"), partner has same nationality1 and no nationality2.
+            // No change in either field.
+            mockChsAppointmentApiData(true, "British");
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(Nationality.BRITISH)
+                    .withNationality2(null)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertNull(filingLimitedPartnerDataDto.getNationality1());
+            assertNull(filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality2Changed_RemoveNationality2() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            // Appointment previously had British/French, partner target removes nationality2 (null).
+            mockChsAppointmentApiData(true, "British,French");
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(Nationality.BRITISH)
+                    .withNationality2(null)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
+            assertNull(filingLimitedPartnerDataDto.getNationality2());
+        }
+
+        @Test
+        void testNationality2Changed_AddNationality2() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            // Appointment previously had only British, partner target adds French as nationality2.
+            mockChsAppointmentApiData(true, "British");
+            var transaction = new TransactionBuilder().build();
+            var limitedPartner = new LimitedPartnerBuilder()
+                    .withPartnershipType(PartnershipType.LP)
+                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
+                    .withNationality1(Nationality.BRITISH)
+                    .withNationality2(Nationality.FRENCH)
+                    .personDto();
+
+            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
+            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
+
+            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
+
+            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
+            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
+
+            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
+            assertEquals("French", filingLimitedPartnerDataDto.getNationality2());
+        }
+
     }
 
     @Nested
@@ -923,14 +1157,18 @@ class FilingsServiceTest {
     }
 
     private void mockChsAppointmentApiData(boolean isPerson) throws URIValidationException, ApiErrorResponseException {
+        mockChsAppointmentApiData(isPerson, NATIONALITY);
+    }
+
+    private void mockChsAppointmentApiData(boolean isPerson, String nationalities) throws URIValidationException, ApiErrorResponseException {
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateDeltaResourceHandler()).thenReturn(privateDeltaResourceHandler);
         when(privateDeltaResourceHandler.getAppointment(any())).thenReturn(privateOfficerGet);
         when(privateOfficerGet.execute()).thenReturn(appointmentFullRecordAPIApiResponse);
-        when(appointmentFullRecordAPIApiResponse.getData()).thenReturn(getAppointmentFullRecordAPI(isPerson));
+        when(appointmentFullRecordAPIApiResponse.getData()).thenReturn(getAppointmentFullRecordAPI(isPerson, nationalities));
     }
 
-    private AppointmentFullRecordAPI getAppointmentFullRecordAPI(boolean isPerson) {
+    private AppointmentFullRecordAPI getAppointmentFullRecordAPI(boolean isPerson, String nationalities) {
         AppointmentFullRecordAPI appointmentFullRecordAPI = new AppointmentFullRecordAPI();
         SensitiveDateOfBirthAPI sensitiveDateOfBirthAPI = new SensitiveDateOfBirthAPI();
         sensitiveDateOfBirthAPI.setDay(15);
@@ -941,7 +1179,7 @@ class FilingsServiceTest {
         if (isPerson) {
             appointmentFullRecordAPI.setForename(PREV_FORENAME);
             appointmentFullRecordAPI.setSurname(PREV_SURNAME);
-            appointmentFullRecordAPI.setNationality(NATIONALITY);
+            appointmentFullRecordAPI.setNationality(nationalities);
         } else {
             appointmentFullRecordAPI.setName(PREV_LEGAL_ENTITY_NAME);
             IdentificationAPI identificationAPI = new IdentificationAPI();

--- a/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/filings/FilingsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/limitedpartnershipsapi/filings/FilingsServiceTest.java
@@ -781,28 +781,35 @@ class FilingsServiceTest {
 
         /**
          * Tests for the nationality1Changed and nationality2Changed boolean logic
-         * in setNationalitiesFields method.
-         *
-         * Truth table:
-         * | partnerNationality1 | appointmentNationality1 | Expected nationality1Changed |
-         * |---------------------|-------------------------|------------------------------|
-         * | null                | null                    | false (unchanged)            |
-         * | null                | "British"               | true (changed)               |
-         * | "British"           | null                    | true (changed)               |
-         * | "British"           | "British"               | false (unchanged)            |
-         * | "British"           | "british" (diff case)   | false (unchanged)            |
-         * | "British"           | "French"                | true (changed)               |
+         * in setNationalitiesFields method, covering both nationality1 and nationality2
+         * change scenarios (unchanged, added, removed, case-insensitive match, differing values).
          */
-
-        @Test
-        void testNationality1Changed_BothNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            mockChsAppointmentApiData(true, null);
+        @ParameterizedTest
+        @CsvSource({
+                // appointmentNationalities, partnerNationality1, partnerNationality2, expectedNationality1, expectedNationality2
+                "'',                          ,       ,        ,       ",
+                "British,                     ,       ,        ,       ",
+                "'',                   BRITISH,       , British,       ",
+                "'British,French',     BRITISH, FRENCH,        ,       ",
+                "'british,french',     BRITISH, FRENCH,        ,       ",
+                "'French,Spanish',     BRITISH,  IRISH, British,  Irish",
+                "British,              BRITISH,       ,        ,       ",
+                "'British,French',     BRITISH,       , British,       ",
+                "British,              BRITISH, FRENCH, British, French"
+        })
+        void testNationalitiesChanged(
+                String appointmentNationalities,
+                Nationality partnerNationality1,
+                Nationality partnerNationality2,
+                String expectedNationality1,
+                String expectedNationality2) throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
+            mockChsAppointmentApiData(true, appointmentNationalities.isEmpty() ? null : appointmentNationalities);
             var transaction = new TransactionBuilder().build();
             var limitedPartner = new LimitedPartnerBuilder()
                     .withPartnershipType(PartnershipType.LP)
                     .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(null)
-                    .withNationality2(null)
+                    .withNationality1(partnerNationality1)
+                    .withNationality2(partnerNationality2)
                     .personDto();
 
             when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
@@ -813,202 +820,8 @@ class FilingsServiceTest {
             List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
             LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
 
-            assertNull(filingLimitedPartnerDataDto.getNationality1());
-            assertNull(filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality1Changed_PartnerNullAppointmentNonNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            // Appointment previously had "British" for nationality1, partner has none set.
-            // Removing nationality1 is not allowed, so both fields are nulled out (no update sent).
-            mockChsAppointmentApiData(true, "British");
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(null)
-                    .withNationality2(null)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertNull(filingLimitedPartnerDataDto.getNationality1());
-            assertNull(filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality1Changed_PartnerNonNullAppointmentNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            // Appointment has no nationality recorded, partner sets nationality1 to "British".
-            // This is a genuine change, so the partner's target value is output.
-            mockChsAppointmentApiData(true, null);
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(Nationality.BRITISH)
-                    .withNationality2(null)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
-            assertNull(filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality1Changed_BothSame() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            mockChsAppointmentApiData(true, "British,French");
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(Nationality.BRITISH)
-                    .withNationality2(Nationality.FRENCH)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertNull(filingLimitedPartnerDataDto.getNationality1());
-            assertNull(filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality1Changed_CaseInsensitiveComparison() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            mockChsAppointmentApiData(true, "british,french");
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(Nationality.BRITISH)
-                    .withNationality2(Nationality.FRENCH)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertNull(filingLimitedPartnerDataDto.getNationality1());
-            assertNull(filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality1Changed_DifferentValues() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            // Appointment previously had French/Spanish, partner target is British/Irish.
-            // Output should reflect the partner's NEW target values, not the appointment's old ones.
-            mockChsAppointmentApiData(true, "French,Spanish");
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(Nationality.BRITISH)
-                    .withNationality2(Nationality.IRISH)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
-            assertEquals("Irish", filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality2Changed_BothNull() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            // Appointment previously had only nationality1 ("British"), partner has same nationality1 and no nationality2.
-            // No change in either field.
-            mockChsAppointmentApiData(true, "British");
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(Nationality.BRITISH)
-                    .withNationality2(null)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertNull(filingLimitedPartnerDataDto.getNationality1());
-            assertNull(filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality2Changed_RemoveNationality2() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            // Appointment previously had British/French, partner target removes nationality2 (null).
-            mockChsAppointmentApiData(true, "British,French");
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(Nationality.BRITISH)
-                    .withNationality2(null)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
-            assertNull(filingLimitedPartnerDataDto.getNationality2());
-        }
-
-        @Test
-        void testNationality2Changed_AddNationality2() throws URIValidationException, ApiErrorResponseException, ResourceNotFoundException {
-            // Appointment previously had only British, partner target adds French as nationality2.
-            mockChsAppointmentApiData(true, "British");
-            var transaction = new TransactionBuilder().build();
-            var limitedPartner = new LimitedPartnerBuilder()
-                    .withPartnershipType(PartnershipType.LP)
-                    .withLimitedPartnerKind(PartnerKind.UPDATE_LIMITED_PARTNER_PERSON.getDescription())
-                    .withNationality1(Nationality.BRITISH)
-                    .withNationality2(Nationality.FRENCH)
-                    .personDto();
-
-            when(limitedPartnerService.getLimitedPartner(transaction, LIMITED_PARTNER_ID)).thenReturn(limitedPartner);
-            when(transactionService.isTransactionLinkedToResource(eq(transaction), any(String.class), eq(limitedPartner.getData().getKind()))).thenReturn(true);
-
-            FilingApi filing = filingsService.generateLimitedPartnerFiling(transaction, LIMITED_PARTNER_ID);
-
-            List<LimitedPartnerDataDto> limitedPartners = (List<LimitedPartnerDataDto>) filing.getData().get(LIMITED_PARTNER_FIELD);
-            LimitedPartnerDataDto filingLimitedPartnerDataDto = limitedPartners.getFirst();
-
-            assertEquals("British", filingLimitedPartnerDataDto.getNationality1());
-            assertEquals("French", filingLimitedPartnerDataDto.getNationality2());
+            assertEquals(expectedNationality1, filingLimitedPartnerDataDto.getNationality1());
+            assertEquals(expectedNationality2, filingLimitedPartnerDataDto.getNationality2());
         }
 
     }


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LP-1812


### Change description
Nationality was being included in filing data for Change partner person forms (LPCH03/04?) when nationalities had not changed.
For example, if person had no nationality2 and it was not changed/updated but name was, it would still include the nationalities in the filings data and then get sent to chips as part of the changed/updated data.


This pull request refines the logic for detecting changes to partner nationalities in the `FilingsService` and significantly expands the test coverage for this logic. The main updates include correcting the comparison logic for nationality fields and adding comprehensive unit tests to verify all scenarios, including case insensitivity and handling of null values.

**Logic improvements:**

* The logic for determining whether `nationality1` and `nationality2` have changed in `setNationalitiesFields` was corrected to handle null values and case-insensitive comparisons more accurately. This ensures updates are only triggered when there is a genuine change between the partner data and the appointment record.

**Test coverage enhancements:**

* Added a comprehensive set of unit tests in `FilingsServiceTest` that cover all combinations of null and non-null values for `nationality1` and `nationality2`, as well as case-insensitive comparisons and scenarios where nationalities are added, removed, or changed. These tests include a truth table for clarity.
* Refactored test helpers to allow injection of appointment nationality values, enabling more granular testing of the nationality change logic. [[1]](diffhunk://#diff-887f8fd6b484875468be6a7b1d3a9da67da2de6ef0e445a5a45b4376f75984ceR1160-R1171) [[2]](diffhunk://#diff-887f8fd6b484875468be6a7b1d3a9da67da2de6ef0e445a5a45b4376f75984ceL944-R1182)

These changes improve both the robustness of the nationality update detection and the reliability of the codebase by ensuring all edge cases are tested.


### Work checklist

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.